### PR TITLE
Refactors

### DIFF
--- a/cli/api.go
+++ b/cli/api.go
@@ -49,10 +49,10 @@ func CreateRootCmd() *cobra.Command {
 
 func createManualCmd() *cobra.Command {
 	manualCmd := &cobra.Command{
-		Use:     "manual",
+		Use:     shared.MANUALCMD,
 		Short:   "Receives profile files and performs data collection and organization. (doesn't wrap go test)",
 		Args:    cobra.MinimumNArgs(1),
-		Example: "prof manual --tag tagName cpu.prof memory.prof block.prof mutex.prof",
+		Example: fmt.Sprintf("prof %s --tag tagName cpu.prof memory.prof block.prof mutex.prof", shared.MANUALCMD),
 		RunE: func(_ *cobra.Command, args []string) error {
 			return collector.RunCollector(args, tag)
 		},
@@ -70,26 +70,26 @@ func createRunCmd() *cobra.Command {
 	profileFlag := "profiles"
 	tagFlag := "tag"
 	countFlag := "count"
-	example := fmt.Sprintf(`prof run --%s BenchmarkGenPool --%s cpu,memory --%s 10 --%s "tag1"`, benchFlag, profileFlag, countFlag, tagFlag)
+	example := fmt.Sprintf(`prof %s --%s BenchmarkGenPool --%s cpu,memory --%s 10 --%s "tag1"`, shared.AUTOCMD, benchFlag, profileFlag, countFlag, tagFlag)
 
-	runCmd := &cobra.Command{
-		Use:     "run",
+	cmd := &cobra.Command{
+		Use:     shared.AUTOCMD,
 		Short:   "Wraps `go test` and `pprof` to benchmark code and gather profiling data for performance investigations.",
 		RunE:    runBenchmarks,
 		Example: example,
 	}
 
-	runCmd.Flags().StringSliceVar(&benchmarks, benchFlag, []string{}, `Benchmarks to run (e.g., "[BenchmarkGenPool]")"`)
-	runCmd.Flags().StringSliceVar(&profiles, profileFlag, []string{}, `Profiles to use (e.g., "[cpu,memory,mutex]")`)
-	runCmd.Flags().StringVar(&tag, tagFlag, "", "The tag is used to organize the results")
-	runCmd.Flags().IntVar(&count, countFlag, 0, "Number of runs")
+	cmd.Flags().StringSliceVar(&benchmarks, benchFlag, []string{}, `Benchmarks to run (e.g., "[BenchmarkGenPool]")"`)
+	cmd.Flags().StringSliceVar(&profiles, profileFlag, []string{}, `Profiles to use (e.g., "[cpu,memory,mutex]")`)
+	cmd.Flags().StringVar(&tag, tagFlag, "", "The tag is used to organize the results")
+	cmd.Flags().IntVar(&count, countFlag, 0, "Number of runs")
 
-	_ = runCmd.MarkFlagRequired(benchFlag)
-	_ = runCmd.MarkFlagRequired(profileFlag)
-	_ = runCmd.MarkFlagRequired(tagFlag)
-	_ = runCmd.MarkFlagRequired(countFlag)
+	_ = cmd.MarkFlagRequired(benchFlag)
+	_ = cmd.MarkFlagRequired(profileFlag)
+	_ = cmd.MarkFlagRequired(tagFlag)
+	_ = cmd.MarkFlagRequired(countFlag)
 
-	return runCmd
+	return cmd
 }
 
 // createTrackCmd creates the track subcommand

--- a/shared/utils.go
+++ b/shared/utils.go
@@ -7,6 +7,12 @@ import (
 	"path/filepath"
 )
 
+// CLI Commands
+const (
+	AUTOCMD   = "auto"
+	MANUALCMD = "manual"
+)
+
 const (
 	InfoCollectionSuccess = "All benchmarks and profile processing completed successfully!"
 	IMPROVEMENT           = "IMPROVEMENT"

--- a/tests/blackbox_test.go
+++ b/tests/blackbox_test.go
@@ -164,7 +164,7 @@ func TestProfileValidation(t *testing.T) {
 	t.Run(label, func(t *testing.T) {
 		profileName := "fakeProfileName"
 		cmd := []string{
-			"run",
+			shared.AUTOCMD,
 			"--benchmarks", benchName,
 			"--profiles", fmt.Sprintf("%s,%s,%s", cpuProfile, memProfile, profileName),
 			"--count", count,
@@ -192,7 +192,7 @@ func TestProfileValidation(t *testing.T) {
 	t.Run(label, func(t *testing.T) {
 		profileName := "goroutine"
 		cmd := []string{
-			"run",
+			shared.AUTOCMD,
 			"--benchmarks", benchName,
 			"--profiles", profileName,
 			"--count", count,
@@ -219,7 +219,7 @@ func TestProfileValidation(t *testing.T) {
 	label = "CollectedProfile"
 	t.Run(label, func(t *testing.T) {
 		cmd := []string{
-			"run",
+			shared.AUTOCMD,
 			"--benchmarks", benchName,
 			"--profiles", fmt.Sprintf("%s,%s,%s", cpuProfile, memProfile, blockProfile),
 			"--count", count,
@@ -248,7 +248,7 @@ func TestCommandValidation(t *testing.T) {
 	label := "EmptyBenchmarkSlice"
 	t.Run(label, func(t *testing.T) {
 		cmd := []string{
-			"run",
+			shared.AUTOCMD,
 			"--benchmarks", "",
 			"--profiles", fmt.Sprintf("%s,%s", cpuProfile, memProfile),
 			"--count", count,
@@ -275,7 +275,7 @@ func TestCommandValidation(t *testing.T) {
 	label = "EmptyProfileSlice"
 	t.Run(label, func(t *testing.T) {
 		cmd := []string{
-			"run",
+			shared.AUTOCMD,
 			"--benchmarks", benchName,
 			"--profiles", "",
 			"--count", count,
@@ -323,7 +323,7 @@ func TestManualCommand(t *testing.T) {
 	label := "BasicRun"
 	t.Run(label, func(t *testing.T) {
 		args := []string{
-			"manual",
+			shared.MANUALCMD,
 			"--tag", tag,
 			"assets/cpu.out",
 			"assets/memory.out",

--- a/tests/helpers.go
+++ b/tests/helpers.go
@@ -429,7 +429,7 @@ func testConfigScenario(t *testing.T, testArgs *TestArgs) {
 
 func defaultRunCmd() []string {
 	return []string{
-		"run",
+		shared.AUTOCMD,
 		"--benchmarks", benchName,
 		"--profiles", fmt.Sprintf("%s,%s", cpuProfile, memProfile),
 		"--count", count,

--- a/tracker/api.go
+++ b/tracker/api.go
@@ -8,6 +8,7 @@ import (
 	"github.com/AlexsanderHamir/prof/shared"
 )
 
+// CheckPerformanceDifferences creates the profile report by comparing data from  prof's auto run.
 func CheckPerformanceDifferences(baselineTag, currentTag, benchName, profileType string) (*ProfileChangeReport, error) {
 	fileName := fmt.Sprintf("%s_%s.txt", benchName, profileType)
 	textFilePath1BaseLine := filepath.Join(shared.MainDirOutput, baselineTag, shared.ProfileTextDir, benchName, fileName)


### PR DESCRIPTION
Replaced hardcoded command strings with constants to improve maintainability—especially important for black-box tests, where changes to command names previously required tedious updates across multiple places.