### PR TITLE
docs: add agent guides and streamline contributor workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# Agent instructions
+
+Entry point for coding agents in **prof** (Go profiling CLI). Navigate to the documentation file that best matches your task.
+
+
+| Need | Doc |
+| --- | --- |
+| Package layout, call flow, invariants, `go test ./...` | [CODEBASE_DESIGN.md](CODEBASE_DESIGN.md) |
+| Test layers, coverage, harness | [TESTING.md](TESTING.md) |
+| PR workflow and contribution steps | [CONTRIBUTING.md](CONTRIBUTING.md) |
+| Tool playbooks (Codegraph MCP, etc.) | [docs/agents/README.md](docs/agents/README.md) |
+| Cursor behavioral rules | [.cursor/rules/](.cursor/rules/) |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,128 +1,94 @@
-# Contributing
+# Contributing to prof
 
-Thanks for your interest in improving **`prof`**! We welcome contributions of all kinds — bug fixes, features, tests, and documentation.
+**Contributing to prof** means opening a pull request with a focused change that passes the same checks CI runs on `main`.
 
-Before starting, check [issues](https://github.com/AlexsanderHamir/prof/issues) to avoid duplication or to pick something up.
+## Before you begin
 
-## Codebase overview
+- **Go 1.24.3+** and **Git**
+- Skim [open issues](https://github.com/AlexsanderHamir/prof/issues) to avoid duplicate work or pick something up
+- When you need package layout, call flow, or invariants, read [CODEBASE_DESIGN.md](CODEBASE_DESIGN.md) first
 
-**Architecture:** CLI → [`internal/app` composition root](internal/app/services.go) → `engine/*` → `parser` / `internal` helpers.
-
-**Principles:**
-
-- Single responsibility per package
-- Stable interfaces at the `app.Services` boundary (easier testing and alternate backends)
-- JSON-driven filters and CI behavior where possible
-- **Errors**: propagate `error`; wrap with `%w`; optional lenience only via documented flags (`--skip-png`, `--lenient-profiles`) — see [CODEBASE_DESIGN.md](CODEBASE_DESIGN.md#error-handling-project-rules).
-
-**Structure (matches the repo tree):**
-
-- `cmd/prof/` – Program entry (`main`)
-- `cli/` – Cobra commands, flags, interactive TUI
-- `internal/app/` – Interfaces and default wiring into engines
-- `engine/collect/` – Unified auto + manual collection (`RunAuto`, `RunManual`)
-- `engine/tooling/` – Subprocess [`Runner`](engine/tooling/runner.go), profile [`Catalog`](engine/tooling/catalog.go), and `go tool pprof` argv helpers
-- `parser/` – pprof decoding, aggregation, line/package reports (`Pipeline`)
-- `internal/config/` – JSON config types and loading
-- `internal/workspace/` – `TagLayout`, module root, bench path constants
-- `tests/` – Integration and blackbox checks
-
-📖 Architecture, edge cases: [CODEBASE_DESIGN.md](CODEBASE_DESIGN.md). Testing layers and coverage: [TESTING.md](TESTING.md).
-
-## Add a profile kind or change `pprof` / `go test` flags
-
-1. Register the profile in [`engine/tooling/catalog.go`](engine/tooling/catalog.go) (`DefaultCatalog`). [`engine/collect/constants.go`](engine/collect/constants.go) rebuilds profile flags from that catalog, and [`internal/app/profiles.go`](internal/app/profiles.go) exposes known names to the CLI.
-2. Run `go test ./...` and update tests under [`engine/tooling`](engine/tooling) or [`engine/collect`](engine/collect) if behavior or argv changes.
-3. External commands must go through [`tooling.Runner`](engine/tooling/runner.go) in production code so tests can inject [`tooling.FakeRunner`](engine/tooling/fake_runner.go).
-
-## Quick Start
-
-**Requirements:** Go 1.24.3+, Git
+## 1. Set up your environment
 
 ```bash
 git clone https://github.com/AlexsanderHamir/prof.git
 cd prof
 go mod tidy
 
-go test ./...
-
 go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
-golangci-lint run
-
-go build -o prof ./cmd/prof
 ```
 
-### Run the CLI while you edit (no `go build` each time)
+## 2. Make your change
 
-From the repo root, run the entrypoint directly with `go run`. Put CLI flags and subcommands **after** `--` so they are not parsed as `go run` flags:
+Run the CLI from the repo root while you edit. Put flags and subcommands **after** `--` so `go run` does not consume them:
 
 ```bash
 go run ./cmd/prof -- version
-go run ./cmd/prof -- benchmark --help
 ```
 
-The Go toolchain keeps a build cache, so after the first compile, most edits only trigger a small incremental rebuild. Use `go build -o prof ./cmd/prof` when you need a fixed binary (for example to copy elsewhere, add to `PATH`, or compare against an installed release).
+After the first compile, `go run` uses the build cache. Use `go build -o prof ./cmd/prof` only when you need a binary on disk.
 
-## Contribution guidelines
+Follow the conventions in [CODEBASE_DESIGN.md](CODEBASE_DESIGN.md#before-you-begin) (layering, subprocess routing, error handling). `golangci-lint` enforces the import and `exec` rules at verify time.
 
-1. **Tests and linting** — Run before pushing:
+## 3. Verify locally
 
-   ```bash
-   go test ./...
-   golangci-lint run
-   ```
+Run both commands from the repository root before every push:
 
-   Coverage report (optional, full suite + per-package table):
+```bash
+go test ./...
+golangci-lint run
+```
 
-   ```bash
-   ./scripts/test-cover.sh          # Linux/macOS
-   .\scripts\test-cover.ps1         # Windows
-   ```
+All packages must pass. For fast loops while editing, fixture regeneration, coverage scripts, and where to add tests, see [TESTING.md](TESTING.md).
 
-   See [TESTING.md](TESTING.md) for layers, fixture commands, and how to read coverage numbers.
+## 4. Open a pull request
 
-   Optional — only edge-case tests (faster while editing them):
+1. One logical change per commit (`feat:`, `fix:`, `docs:`, `refactor:`).
+2. Write a clear summary; use `Closes #123` when an issue applies.
+3. Expect review and iterative feedback.
 
-   ```bash
-   go test ./tests -count=1 -run '^TestEdge'
-   ```
+Coding agents: [AGENTS.md](AGENTS.md).
 
-2. **Code style** — Idiomatic Go; small functions; exported symbols commented when non-obvious. **Subprocesses:** do not call `exec.Command` or `exec.CommandContext` outside `engine/tooling` (`exec_runner.go`, `lookpath.go`) or the `tests/` tree — **golangci-lint forbidigo** enforces this; use [`tooling.ExecRunner`](engine/tooling/exec_runner.go) and [`tooling.LookPath`](engine/tooling/lookpath.go) instead.
+## Maintainer: cut a release
 
-3. **Commits** — One logical change per commit; descriptive messages (`feat:`, `fix:`, `docs:`, `refactor:`).
+Releases are manual. Open **Actions → Release → Run workflow** on the branch to ship (usually `main`).
 
-4. **Tests** — Prefer tests for bug fixes and new behavior; integration tests when touching CLI/output layout.
+| Outcome | Detail |
+| --- | --- |
+| Version bump | Next patch from the latest `v*` tag via [`svu`](https://github.com/caarlos0/svu); no tag yet → `v0.1.0` |
+| Failure | Errors when there are no new commits since the last tag, or the computed tag already exists |
+| Success | Multi-platform binaries, checksums, annotated tag, GitHub release with auto-generated notes |
 
-   The integration suite under `tests/` reads committed pprof binaries from `tests/assets/fixtures/` to keep filter-behavior tests deterministic and fast. When you change `tests/assets/utils.go.txt` or `tests/assets/benchmark_test.go.txt`, regenerate the fixtures with:
+```bash
+go install github.com/AlexsanderHamir/prof/cmd/prof@VX.Y.Z
+```
 
-   ```bash
-   go generate ./tests/...
-   ```
+## Task recipes
 
-5. **Releases** — Versioning and release notes are **automated**, but a release **never runs by itself**. You must **start it by hand** in GitHub each time you want to ship.
+### Add a profile kind
 
-   - **Nothing triggers a release automatically** — not merging to `main`, not pushes, not schedules. Only **Actions → Release → Run workflow** (you click **Run workflow** and choose the branch, usually `main`).
-   - After you click **Run**, the workflow picks the next **patch** version from the latest `v*` tag using [`svu`](https://github.com/caarlos0/svu) (e.g. `v1.2.3` → `v1.2.4`). You do **not** type a version. If there is no tag yet, it publishes **`v0.1.0`**.
-   - It **stops with an error** if there are **no new commits** since the last tag, or if the computed tag **already exists**.
-   - On success it builds `prof` for common `GOOS`/`GOARCH` pairs, attaches checksums, pushes an **annotated tag** on the commit you ran the workflow from, and creates a GitHub release with **auto-generated release notes** (PRs and commits since the previous release).
+1. Register in [`engine/tooling/catalog.go`](engine/tooling/catalog.go) (`DefaultCatalog`).
+2. Confirm [`engine/collect/constants.go`](engine/collect/constants.go) and [`internal/app/profiles.go`](internal/app/profiles.go) pick it up.
+3. Run `go test ./...`; update [`engine/tooling`](engine/tooling) or [`engine/collect`](engine/collect) tests if argv or behavior changed.
 
-   Install a released version with Go tooling, for example:
+Use [`tooling.Runner`](engine/tooling/runner.go) in production code so tests can inject [`tooling.FakeRunner`](engine/tooling/fake_runner.go).
 
-   ```bash
-   go install github.com/AlexsanderHamir/prof/cmd/prof@v1.2.4
-   ```
+### Update documentation
 
-6. **Documentation** — Update [readme.md](readme.md), [prof_web_doc/](prof_web_doc/), [CODEBASE_DESIGN.md](CODEBASE_DESIGN.md), or CLI help when user-visible behavior changes.
+| You changed | Edit |
+| --- | --- |
+| User install, usage, troubleshooting | [readme.md](readme.md), [prof_web_doc/](prof_web_doc/) |
+| Architecture or invariants | [CODEBASE_DESIGN.md](CODEBASE_DESIGN.md) |
+| CLI help | [`cli/`](cli/) command definitions |
+| Agent tool playbooks | [docs/agents/](docs/agents/) |
 
-7. **Pull requests** — Clear summary; reference issues (`Closes #123`).
+Define each workflow once; link instead of copying. User docs: [prof_web_doc/docs/index.md](prof_web_doc/docs/index.md). Tone: [Microsoft Writing Style Guide](https://learn.microsoft.com/en-us/style-guide/welcome/).
 
-8. **Reviews** — Discussion and iterative feedback welcome.
+## Further reading
 
-## Documentation style
-
-Goal: **maximum help, minimum words.** Follow [Microsoft Writing Style Guide](https://learn.microsoft.com/en-us/style-guide/welcome/) (you, active voice, sentence-case headings, descriptive links) without padding.
-
-- **Brevity first** — Cut sentences that do not answer a question, prevent a mistake, or remove duplication.
-- **Link, do not repeat** — Define terms and workflows once (usually [prof_web_doc/docs/index.md](prof_web_doc/docs/index.md)); other pages link there instead of restating.
-- **Shape** — Prefer tables and bullets over long prose; numbered steps only for real sequences; skip empty “Prerequisites” sections.
-- **Callouts** (`!!! note`, `!!! tip`, `!!! important`, `!!! warning` in MkDocs) — Only for high-signal cases (TTY required, CI exit codes, data loss risk). Few beats many.
+| Doc | Use when |
+| --- | --- |
+| [CODEBASE_DESIGN.md](CODEBASE_DESIGN.md) | Navigating or changing the codebase |
+| [TESTING.md](TESTING.md) | Writing or debugging tests |
+| [readme.md](readme.md) | User-facing behavior |
+| [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) | Community standards |

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -1,0 +1,13 @@
+# Agent guides
+
+On-demand playbooks for agents. Read a guide when the task matches, not at session start.
+
+| Guide | Read when |
+| --- | --- |
+| [codegraph-tools.md](./codegraph-tools.md) | Go symbol lookup, call graph, or refactor prep with Codegraph MCP (`user-codegraph`) |
+
+## Conventions
+
+- **File names:** `{topic}-tools.md` for tool playbooks; `{area}-navigation.md` for codebase orientation.
+- **Measured on this repo:** guides cite real prof-polish paths and symbols, not generic advice.
+- **Fallbacks:** each guide states when to use Read, Grep, or Glob instead.

--- a/docs/agents/codegraph-tools.md
+++ b/docs/agents/codegraph-tools.md
@@ -1,0 +1,88 @@
+# Codegraph MCP tools — agent guide
+
+Codegraph is a per-project SQLite index of symbols, call edges, and file metadata. Every MCP tool on the `user-codegraph` server reads from that index rather than scanning the tree on each request, which makes symbol lookup and call-graph traversal faster and more structured than ad-hoc Grep and Read loops. The index lives under `.codegraph/` at the project root and is built with `codegraph init`; until it exists, none of the tools below apply and you should fall back to Read, Grep, and Glob. All tools accept `projectPath` (an absolute path to the repo or any subdirectory inside it) because the server has no default project when the workspace root itself is unindexed — pass the repo root path or equivalent on every call.
+
+---
+
+## Starting with the index
+
+Before any other tool, confirm the index is present and healthy with `codegraph_status`. On a freshly initialized prof-polish repo this returned 135 indexed files, 1,351 nodes, and 2,937 edges along with a breakdown by symbol kind (functions, methods, imports, and so on) and by language. The tool adds no semantic value during normal exploration — its job is diagnostics when a query returns empty results, after a large refactor, or when you suspect the index is stale. **Pros:** one call tells you whether Codegraph is usable at all. **Cons:** no code, no graph, no file listing. **When to use:** once at session start if unsure, or when other tools fail unexpectedly. **Combine with:** nothing routinely; if status shows zero files, run `codegraph init` and retry.
+
+Once the index is confirmed, orient yourself in the tree with `codegraph_files`. Filtering `path=engine/collect` and `format=tree` produced the same 21 Go files that Glob finds, but each entry included a symbol count (for example `entry.go` with 11 symbols) and the output was already hierarchical. The `grouped` format rolls files up by language, and `pattern` accepts globs such as `*.go`. **Pros:** faster than Glob for layout questions because results come from the index and carry symbol density; supports depth limits and flat/tree/grouped views. **Cons:** only lists indexed source files — configs, markdown, and other non-parsed paths are absent, with no file timestamps or sizes. **When to use:** "what lives under this package?" or "how big is this area?" before diving into symbols. **Combine with:** `codegraph_search` next, using the file paths you just discovered as disambiguation hints.
+
+---
+
+## Finding symbols
+
+`codegraph_search` resolves a name (full or partial) to definition sites. Searching `RunAuto` with `kind=function` returned a single canonical hit at `engine/collect/entry.go:15` with its signature, while Grep for `func RunAuto` found only that one definition but missed six interface methods and test stubs that share the name, and a plain Grep for `RunAuto` returned twenty-five noisy hits spanning comments, call sites, and documentation. **Pros:** definition-oriented, typed results with file, line, and signature; optional `kind` filter narrows to functions, methods, classes, routes, components, and other node kinds. **Cons:** locations only — no source bodies; requires knowing (or guessing) a symbol name rather than a concept. **When to use:** you know what something is called and need to find where it is defined. **Combine with:** `codegraph_node` on the hit you care about, passing `file` when the name is overloaded.
+
+---
+
+## Reading source
+
+`codegraph_node` has two modes and is the workhorse for anything that would otherwise use Read. In **file mode**, pass `file` alone (path or basename). Reading `engine/collect/entry.go` returned the same line-numbered source as the Read tool, prefixed with a header noting the file is used by two others (`manual_test.go` and `internal/app/defaults.go`). Setting `symbolsOnly=true` instead returned just the three symbol signatures and line numbers — a cheap structural preview. `offset` and `limit` paginate exactly like Read. A request for a non-existent `auto.go` failed with a clear message to use Read for non-indexed paths. **Pros:** drop-in Read replacement with dependents attached; index-backed so repeated reads are cheap. **Cons:** capped at 2,000 lines; wrong filenames error rather than falling back.
+
+In **symbol mode**, pass `symbol` (optionally with `file` and `line` to pin one overload). Querying `RunAuto` with `includeCode=true` and no disambiguation returned all seven definitions — interface methods, test fakes, and the real function — each with its full body and a caller/callee trail. Pinning with `file=engine/collect/entry.go` and `line=15` collapsed that to the single production definition plus its trail: calls to `applyAutoSkipPNG`, `config.Load`, `setupDirectories`, and `runBenchAndGetProfiles`; called by `defaultCollect.RunAuto` and a test. **Pros:** replaces search + Read + manual trace for one symbol; disambiguates overloaded names without opening every matching file. **Cons:** ambiguous names with `includeCode=true` produce very large responses; trails are one hop unless you follow them manually.
+
+**When to use file mode:** any time you would Read a source file, especially when you also want to know who imports or depends on it. **When to use symbol mode:** before editing a function, method, or type — always prefer pinning with `file` when the name appears in tests or interfaces. **Combine with:** `codegraph_callers` and `codegraph_callees` when you need the full caller or callee list rather than the inline trail.
+
+---
+
+## Traversing the call graph
+
+The three graph tools slice the same edge data along different axes. `codegraph_callers` lists who invokes a symbol; without a `file` filter on `RunAuto` it grouped seven distinct definitions (interface declarations, test stubs, and the real function), but adding `file=engine/collect/entry.go` narrowed to two direct callers: `TestRunAuto_validation` and `defaultCollect.RunAuto`. Dynamic interface dispatch is labeled explicitly (for example `RunAuto (internal/app/services.go:13) [dynamic: interface → impl @…]`). **Pros:** precise inbound edges, grouped per definition, with interface resolution noted. **Cons:** common names require `file`; default limit is twenty; no source code.
+
+`codegraph_callees` mirrors this for outbound calls. The production `RunAuto` at `entry.go:15` calls nine functions and references several types in one hop. **Pros:** immediate dependency list for a single symbol. **Cons:** one level deep only; type references mixed with function calls can clutter the picture.
+
+`codegraph_impact` walks multiple hops to answer "what breaks if I change this?" Analyzing `GetFunctionListEntriesV2` at `depth=2` surfaced four affected symbols across `parser/facade.go` and `parser/coverage_more_test.go`. The `file` parameter disambiguates when several symbols share a name; `depth` controls how far the traversal reaches (default 2). **Pros:** refactor planning in one call instead of chaining callers manually. **Cons:** output is a flat symbol list with no ranking by risk and no code context.
+
+**When to use callers:** before changing a function signature or deleting an export — verify every inbound site. **When to use callees:** understanding what a function orchestrates without reading its entire body. **When to use impact:** scoping a rename, signature change, or extraction across packages. **Combine with:** `codegraph_node` with `includeCode=true` on the highest-risk symbols impact returns, then `codegraph_callers` again if you need the complete inbound set beyond impact's depth window.
+
+---
+
+## The missing aggregate tool
+
+Server documentation and several tool descriptions reference `codegraph_explore` as a single-call replacement for search + node + callers + callees when understanding an area. **It is not registered on the MCP server** (calls return "tool not found" as of this benchmark). Until it ships, reproduce its intent with a fixed four-step recipe: `codegraph_search` to locate the entry symbol, `codegraph_node` with `includeCode=true` and a `file` pin to read the body and inline trail, `codegraph_callers` with the same `file` pin for the full inbound set, and `codegraph_callees` for outbound dependencies. That sequence understood the collect pipeline's `RunAuto` entry point in four round trips versus six or more with Grep and Read.
+
+---
+
+## Named workflows
+
+**New area onboarding.** Run `codegraph_files` on the package directory to see file count and symbol density, then `codegraph_search` for the entry function or route name you expect, then `codegraph_node` in symbol mode with `includeCode=true` and a `file` pin. This replaces Glob → Grep → Read with three indexed calls and gives you dependents and a one-hop trail for free.
+
+**Refactor prep.** After `codegraph_search` locates the symbol, call `codegraph_impact` with an appropriate `depth` (2 for local changes, higher for API surface changes). For each returned symbol, call `codegraph_node` with `includeCode=true` to inspect bodies, and `codegraph_callers` with `file` if impact's depth missed a caller you care about.
+
+**Pin an ambiguous symbol.** Call `codegraph_node` with just `symbol` to list all definitions (twelve matches for `Run` in prof-polish). Pick the `file:line` from the list, then re-query with `symbol`, `file`, and `line` to get one body and trail. This avoids the token cost of `includeCode=true` on every overload upfront.
+
+**Read a file before editing.** Prefer `codegraph_node` with `file` over Read: same source format, plus a dependents note that tells you whether the edit might ripple. Use `symbolsOnly=true` first if the file is long and you only need to know what symbols it exports.
+
+---
+
+## When to fall back to built-in tools
+
+| Situation | Use instead |
+| --- | --- |
+| No `.codegraph/` index or `codegraph_status` shows zero files | Read, Grep, Glob; run `codegraph init` |
+| Non-source files (markdown, YAML configs, `.env`, CI) | Read or Grep — only parsed languages are indexed |
+| Wrong or stale path after a rename | Read directly; re-run `codegraph init` if the index is old |
+| Concept search ("where is auth handled?") | SemanticSearch or Grep — Codegraph needs a symbol name |
+| String literal or comment search | Grep — the index tracks symbols and call edges, not all text |
+| `codegraph_explore`-style area query | Four-tool recipe above until explore is available |
+
+---
+
+## Tool summary
+
+| Tool | Best for | Avoid when |
+| --- | --- | --- |
+| `codegraph_status` | Index health check | Normal exploration |
+| `codegraph_files` | Package layout, symbol counts | Non-indexed paths |
+| `codegraph_search` | Find definitions by name | You need source or call graph |
+| `codegraph_node` (file) | Read source + dependents | File not in index |
+| `codegraph_node` (symbol) | Body + trail before edit | Ambiguous name without `file` pin |
+| `codegraph_callers` | Full inbound call list | Name is overloaded without `file` |
+| `codegraph_callees` | Outbound dependencies | You need multi-hop reach |
+| `codegraph_impact` | Refactor blast radius | You need code bodies inline |
+| `codegraph_explore` | *(unavailable)* | — |
+
+All observations above were measured against the prof-polish Go codebase (135 files, 1,351 nodes) using symbols along the collect→parser call chain (`RunAuto`, `GetFunctionListEntriesV2`, and related paths). Adjust `depth`, `limit`, and disambiguation habits for larger monorepos where name collisions are more frequent.


### PR DESCRIPTION
## Summary

- Add `AGENTS.md` as a thin router for coding agents (links to architecture, testing, contributing, and tool playbooks).
- Add `docs/agents/` with a Codegraph MCP playbook and guide index.
- Refactor `CONTRIBUTING.md` into a linear setup → change → verify → PR flow, linking to `CODEBASE_DESIGN.md` and `TESTING.md` instead of duplicating them.

## Test plan

- [ ] Read `AGENTS.md` and confirm each link resolves
- [ ] Read `CONTRIBUTING.md` end-to-end; verify no broken cross-references
- [ ] Skim `docs/agents/codegraph-tools.md` for accuracy against current Codegraph MCP tools

Made with [Cursor](https://cursor.com)