### PR TITLE
fix(ci): harden GitHub Pages docs deploy

### DIFF
--- a/.github/workflows/docs-pages.yaml
+++ b/.github/workflows/docs-pages.yaml
@@ -15,11 +15,15 @@ permissions:
 
 concurrency:
   group: pages
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
 
@@ -35,16 +39,41 @@ jobs:
       - name: Build site
         run: mkdocs build --strict -f prof_web_doc/mkdocs.yml
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v4
         with:
           path: prof_web_doc/site
 
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      url: ${{ steps.deployment_retry.outputs.page_url || steps.deployment.outputs.page_url }}
+    timeout-minutes: 15
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
+        continue-on-error: true
+        with:
+          # Poll longer on transient Pages backend failures (see actions/deploy-pages#418).
+          reporting_interval: 10000
+          error_count: 15
+
+      - name: Retry Pages deploy after transient failure
+        if: steps.deployment.outcome == 'failure'
+        id: deployment_retry
+        uses: actions/deploy-pages@v5
+        with:
+          reporting_interval: 10000
+          error_count: 15
+
+      - name: Require successful Pages deploy
+        if: steps.deployment.outcome == 'failure' && steps.deployment_retry.outcome == 'failure'
+        run: |
+          echo "GitHub Pages deploy failed after two attempts."
+          echo "Re-run this workflow from Actions, or check Settings → Pages → Source: GitHub Actions."
+          exit 1


### PR DESCRIPTION
## Summary
The docs deploy workflow built successfully but `actions/deploy-pages` failed with the generic `Deployment failed, try again later` error after PR #103 merged. The build artifact was valid; this matches transient GitHub Pages backend failures reported in [actions/deploy-pages#418](https://github.com/actions/deploy-pages/issues/418).

This PR hardens `.github/workflows/docs-pages.yaml`:

- Set `concurrency.cancel-in-progress: true` so a new docs deploy cancels a stuck in-progress deployment instead of wedging the queue.
- Upgrade `upload-pages-artifact` to v4 and `deploy-pages` to v5.
- Add explicit job permissions on build/deploy jobs.
- Increase deploy polling (`reporting_interval`, `error_count`) and retry the deploy step once before failing.
- Add a clearer failure message pointing at re-run and Pages settings.

## Test plan
- [ ] Merge and confirm **Deploy documentation** succeeds on `main`
- [ ] Or run **Deploy documentation** manually via `workflow_dispatch` after merge
- [ ] Verify https://alexsanderhamir.github.io/prof/ serves updated docs
