### PR TITLE
fix(ci): silence Pages punycode warning and trigger deploy on workflow edits

### DIFF
--- a/.github/workflows/docs-pages.yaml
+++ b/.github/workflows/docs-pages.yaml
@@ -6,6 +6,7 @@ on:
     branches: [main]
     paths:
       - "prof_web_doc/**"
+      - ".github/workflows/docs-pages.yaml"
   workflow_dispatch:
 
 permissions:
@@ -46,6 +47,9 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    env:
+      # deploy-pages runs on Node 24; silence upstream punycode DEP0040 until action deps update.
+      NODE_OPTIONS: --disable-warning=DEP0040
     permissions:
       contents: read
       pages: write


### PR DESCRIPTION
## Summary
Follow-up to PR #105. Clarifies what those deploy logs meant and finishes the remaining cleanup.

| Log line | Status on `main` after #105 | This PR |
|----------|----------------------------|---------|
| `Node 20 is being deprecated` (from `deploy-pages@v4`) | **Fixed** — workflow uses `deploy-pages@v5` (Node 24) | No change needed |
| `punycode` DEP0040 warning | **Not fixed** — comes from Node 24 + action dependencies | Set `NODE_OPTIONS: --disable-warning=DEP0040` on deploy job |
| `Deployment failed, try again later` | **Mitigated** — retry + `cancel-in-progress` | Also trigger deploy when the workflow file changes so fixes are actually exercised |

## Test plan
- [ ] Merge and confirm **Deploy documentation** runs (this PR changes the workflow path filter)
- [ ] Deploy job logs no longer show punycode DEP0040
- [ ] Site updates at https://alexsanderhamir.github.io/prof/
