### PR TITLE
refactor: data-descriptive bench/<tag>/ artifact domains

### DIFF
--- a/CODEBASE_DESIGN.md
+++ b/CODEBASE_DESIGN.md
@@ -113,10 +113,12 @@ All paths come from [`workspace.TagLayout`](internal/workspace/layout.go):
 ```text
 bench/
 └── <tag>/
-    ├── description.txt
-    ├── bin/<BenchmarkName>/<BenchmarkName>_<profile>.out
-    ├── text/<BenchmarkName>/<BenchmarkName>_<profile>.txt
-    └── <profile>_functions/<BenchmarkName>/<function>.txt
+    ├── notes.txt
+    ├── profiles/<BenchmarkName>/<profile>.out
+    ├── measurements/<BenchmarkName>/run.txt
+    ├── hotspots/<BenchmarkName>/<profile>.txt
+    ├── source_lines/<profile>/<BenchmarkName>/<function>.txt
+    └── call_graphs/<profile>/<BenchmarkName>/<profile>.png
 ```
 
 ## Configuration (`prof.json`)

--- a/docs/collect-request-flow.md
+++ b/docs/collect-request-flow.md
@@ -122,7 +122,7 @@ flowchart TB
 [`setupDirectories`](../engine/collect/layout.go) (inside **Preparing** on TTY, or before config print on non-TTY):
 
 - Resolves `bench/<tag>/` with [`workspace.CleanOrCreateTag`](../internal/workspace/tag.go).
-- Creates `bin/<benchmark>/`, `text/<benchmark>/`, `<profile>_functions/<benchmark>/`, and `description.txt`.
+- Creates `profiles/<benchmark>/`, `measurements/<benchmark>/`, `hotspots/<benchmark>/`, `source_lines/<profile>/<benchmark>/`, and `notes.txt`.
 
 ### 3–5. Per-benchmark progress (TTY)
 
@@ -130,8 +130,8 @@ flowchart TB
 
 | Step | Label (TTY stderr) | Internal work |
 | --- | --- | --- |
-| 1 | `Running benchmark 1/2: BenchmarkX (count=5)…` | [`runBenchmark`](../engine/collect/gotest.go): `go test`, write bench text, [`moveProfileFiles`](../engine/collect/artifacts.go) |
-| 2 | `Collecting profiles for BenchmarkX (cpu, memory)…` | [`processProfiles`](../engine/collect/profiles.go): text + PNG |
+| 1 | `Running benchmark 1/2: BenchmarkX (count=5)…` | [`runBenchmark`](../engine/collect/gotest.go): `go test`, write `measurements/.../run.txt`, [`moveProfileFiles`](../engine/collect/artifacts.go) |
+| 2 | `Collecting profiles for BenchmarkX (cpu, memory)…` | [`processProfiles`](../engine/collect/profiles.go): hotspots + call graphs |
 | 3 | `Collecting function profiles for BenchmarkX…` | [`collectProfileFunctions`](../engine/collect/pipeline.go): parser + per-function `pprof -list` |
 
 On an interactive TTY after Survey:
@@ -165,7 +165,7 @@ For `BenchmarkMatrixMultiplication`, [`runBenchmark`](../engine/collect/gotest.g
 - Locates the package directory containing the benchmark function.
 - Builds `go test -run=^$ -bench=^BenchmarkMatrixMultiplication$ -benchmem -count=5` plus profile flags from the tooling catalog (`cpu`, `memory`).
 - Runs the command in the benchmark package directory via [`tooling.Runner`](../engine/tooling/runner.go).
-- Writes combined benchmark output to the tag text file; moves profile binaries (`.out`) into `bench/Baseline/bin/BenchmarkMatrixMultiplication/`. Failures return combined output in the error.
+- Writes combined benchmark output to `measurements/<benchmark>/run.txt`; moves profile binaries (`.out`) into `bench/Baseline/profiles/BenchmarkMatrixMultiplication/`. Failures return combined output in the error.
 
 #### Step 2 — Process profiles
 
@@ -174,8 +174,8 @@ For `BenchmarkMatrixMultiplication`, [`runBenchmark`](../engine/collect/gotest.g
 | Step | Output | Notes for this example |
 | --- | --- | --- |
 | Stat binary | — | Missing `.out` logs a warning and skips that profile instead of failing |
-| Text profile | `text/.../BenchmarkMatrixMultiplication_cpu.txt` (and `_memory.txt`) | Via `go tool pprof` |
-| PNG | `<profile>_functions/.../BenchmarkMatrixMultiplication.png` | PNG failure logs a warning; run still succeeds if text profiles were produced |
+| Hotspot summary | `hotspots/.../cpu.txt` (and `memory.txt`) | Via `go tool pprof` |
+| PNG | `call_graphs/<profile>/.../cpu.png` | PNG failure logs a warning; run still succeeds if hotspot summaries were produced |
 
 Resolved function filters for each benchmark come from `config.ResolveCollectionFilter` (same rules previewed during the Survey step).
 
@@ -184,7 +184,7 @@ Resolved function filters for each benchmark come from `config.ResolveCollection
 [`collectProfileFunctions`](../engine/collect/pipeline.go):
 
 - For each successfully processed profile, [`parser.GetFunctionListEntriesV2`](../parser/) reads the binary and applies config filters.
-- `go tool pprof -list` output is written under `cpu_functions/BenchmarkMatrixMultiplication/` and `memory_functions/BenchmarkMatrixMultiplication/`.
+- `go tool pprof -list` output is written under `source_lines/cpu/BenchmarkMatrixMultiplication/` and `source_lines/memory/BenchmarkMatrixMultiplication/`.
 
 When all benchmarks finish, prof logs collection success and returns.
 
@@ -195,20 +195,22 @@ All paths come from [`workspace.TagLayout`](../internal/workspace/layout.go). Fo
 ```text
 bench/
 └── Baseline/
-    ├── description.txt
-    ├── bin/BenchmarkMatrixMultiplication/
-    │   ├── BenchmarkMatrixMultiplication_cpu.out
-    │   └── BenchmarkMatrixMultiplication_memory.out
-    ├── text/BenchmarkMatrixMultiplication/
-    │   ├── BenchmarkMatrixMultiplication_cpu.txt
-    │   └── BenchmarkMatrixMultiplication_memory.txt
-    ├── cpu_functions/BenchmarkMatrixMultiplication/
+    ├── notes.txt
+    ├── profiles/BenchmarkMatrixMultiplication/
+    │   ├── cpu.out
+    │   └── memory.out
+    ├── measurements/BenchmarkMatrixMultiplication/
+    │   └── run.txt
+    ├── hotspots/BenchmarkMatrixMultiplication/
+    │   ├── cpu.txt
+    │   └── memory.txt
+    ├── source_lines/cpu/BenchmarkMatrixMultiplication/
     │   └── <function>.txt
-    └── memory_functions/BenchmarkMatrixMultiplication/
+    └── source_lines/memory/BenchmarkMatrixMultiplication/
         └── <function>.txt
 ```
 
-PNG files, when generated, live under `<profile>_functions/<benchmark>/`.
+PNG files, when generated, live under `call_graphs/<profile>/<benchmark>/`.
 
 ## Where to change behavior
 

--- a/engine/collect/artifacts.go
+++ b/engine/collect/artifacts.go
@@ -54,7 +54,7 @@ func isGoTestBinary(name string) bool {
 	return strings.HasSuffix(strings.ToLower(name), ".test.exe")
 }
 
-func moveProfileFiles(benchmarkName string, profiles []string, rootDir string, binDir string) error {
+func moveProfileFiles(profiles []string, rootDir string, binDir string) error {
 	for _, profile := range profiles {
 		profileFile, ok := getExpectedProfileFileName(profile)
 		if !ok {

--- a/engine/collect/artifacts.go
+++ b/engine/collect/artifacts.go
@@ -67,7 +67,7 @@ func moveProfileFiles(benchmarkName string, profiles []string, rootDir string, b
 		if latestPath == "" {
 			continue
 		}
-		destPath := filepath.Join(binDir, fmt.Sprintf("%s_%s.%s", benchmarkName, profile, workspace.ProfileArtifactExtension))
+		destPath := filepath.Join(binDir, fmt.Sprintf("%s.%s", profile, workspace.ProfileArtifactExtension))
 		if err = os.Rename(latestPath, destPath); err != nil {
 			return fmt.Errorf("failed to move profile file %s: %w", latestPath, err)
 		}

--- a/engine/collect/doc.go
+++ b/engine/collect/doc.go
@@ -1,2 +1,4 @@
 // Package collect runs auto and manual profile collection under bench/<tag>/.
+// Artifacts are grouped by data domain: profiles, measurements, hotspots,
+// source_lines, and call_graphs (see internal/workspace.TagLayout).
 package collect

--- a/engine/collect/gotest.go
+++ b/engine/collect/gotest.go
@@ -78,8 +78,8 @@ func runBenchmark(runner tooling.Runner, benchmarkName string, profiles []string
 	if err != nil {
 		return fmt.Errorf("failed to locate benchmark %s: %w", benchmarkName, err)
 	}
-	outputFile := layout.BenchText(benchmarkName)
-	binDir := filepath.Join(layout.Root, workspace.ProfileBinDir, benchmarkName)
+	outputFile := layout.Measurement(benchmarkName)
+	binDir := filepath.Join(layout.Root, workspace.ProfilesDir, benchmarkName)
 	if err = runBenchmarkCommand(runner, cmd, outputFile, pkgDir); err != nil {
 		return err
 	}

--- a/engine/collect/gotest.go
+++ b/engine/collect/gotest.go
@@ -83,7 +83,7 @@ func runBenchmark(runner tooling.Runner, benchmarkName string, profiles []string
 	if err = runBenchmarkCommand(runner, cmd, outputFile, pkgDir); err != nil {
 		return err
 	}
-	if err = moveProfileFiles(benchmarkName, profiles, pkgDir, binDir); err != nil {
+	if err = moveProfileFiles(profiles, pkgDir, binDir); err != nil {
 		return err
 	}
 	return moveTestFiles(benchmarkName, pkgDir, binDir)

--- a/engine/collect/layout.go
+++ b/engine/collect/layout.go
@@ -10,28 +10,27 @@ import (
 )
 
 func createBenchDirectories(tagDir string, benchmarks []string, quiet bool) error {
-	binDir := filepath.Join(tagDir, workspace.ProfileBinDir)
-	textDir := filepath.Join(tagDir, workspace.ProfileTextDir)
-	descFile := filepath.Join(tagDir, workspace.BenchDescriptionFileName)
+	profilesDir := filepath.Join(tagDir, workspace.ProfilesDir)
+	measurementsDir := filepath.Join(tagDir, workspace.MeasurementsDir)
+	hotspotsDir := filepath.Join(tagDir, workspace.HotspotsDir)
+	notesFile := filepath.Join(tagDir, workspace.TagNotesFileName)
 
-	if err := os.Mkdir(binDir, workspace.PermDir); err != nil {
-		return fmt.Errorf("failed to create bin directory: %w", err)
-	}
-	if err := os.Mkdir(textDir, workspace.PermDir); err != nil {
-		return fmt.Errorf("failed to create text directory: %w", err)
+	for _, dir := range []string{profilesDir, measurementsDir, hotspotsDir} {
+		if err := os.Mkdir(dir, workspace.PermDir); err != nil {
+			return fmt.Errorf("failed to create %s directory: %w", filepath.Base(dir), err)
+		}
 	}
 
 	for _, b := range benchmarks {
-		if err := os.Mkdir(filepath.Join(binDir, b), workspace.PermDir); err != nil {
-			return fmt.Errorf("failed to create bin subdirectory for %s: %w", b, err)
-		}
-		if err := os.Mkdir(filepath.Join(textDir, b), workspace.PermDir); err != nil {
-			return fmt.Errorf("failed to create text subdirectory for %s: %w", b, err)
+		for _, dir := range []string{profilesDir, measurementsDir, hotspotsDir} {
+			if err := os.Mkdir(filepath.Join(dir, b), workspace.PermDir); err != nil {
+				return fmt.Errorf("failed to create %s subdirectory for %s: %w", filepath.Base(dir), b, err)
+			}
 		}
 	}
 
-	if err := os.WriteFile(descFile, []byte(workspace.BenchDescriptionPlaceholder), workspace.PermFile); err != nil {
-		return fmt.Errorf("failed to create description file: %w", err)
+	if err := os.WriteFile(notesFile, []byte(workspace.TagNotesPlaceholder), workspace.PermFile); err != nil {
+		return fmt.Errorf("failed to create notes file: %w", err)
 	}
 
 	if !quiet {
@@ -40,21 +39,25 @@ func createBenchDirectories(tagDir string, benchmarks []string, quiet bool) erro
 	return nil
 }
 
-func createProfileFunctionDirectories(tagDir string, profiles, benchmarks []string, quiet bool) error {
+func createSourceLinesDirectories(tagDir string, profiles, benchmarks []string, quiet bool) error {
+	sourceLinesRoot := filepath.Join(tagDir, workspace.SourceLinesDir)
+	if err := os.Mkdir(sourceLinesRoot, workspace.PermDir); err != nil {
+		return fmt.Errorf("failed to create source_lines directory: %w", err)
+	}
 	for _, profileName := range profiles {
-		profileDirPath := filepath.Join(tagDir, profileName+workspace.FunctionsDirSuffix)
-		if err := os.Mkdir(profileDirPath, workspace.PermDir); err != nil {
-			return fmt.Errorf("failed to create profile directory %s: %w", profileDirPath, err)
+		profileRoot := filepath.Join(sourceLinesRoot, profileName)
+		if err := os.Mkdir(profileRoot, workspace.PermDir); err != nil {
+			return fmt.Errorf("failed to create source_lines/%s directory: %w", profileName, err)
 		}
 		for _, b := range benchmarks {
-			benchmarkDirPath := filepath.Join(profileDirPath, b)
+			benchmarkDirPath := filepath.Join(profileRoot, b)
 			if err := os.Mkdir(benchmarkDirPath, workspace.PermDir); err != nil {
 				return fmt.Errorf("failed to create benchmark directory %s: %w", benchmarkDirPath, err)
 			}
 		}
 	}
 	if !quiet {
-		slog.Info("Created profile function directories")
+		slog.Info("Created source_lines directories")
 	}
 	return nil
 }
@@ -70,5 +73,5 @@ func setupDirectories(tag string, benchmarks, profiles []string, quiet bool) err
 	if err = createBenchDirectories(tagDir, benchmarks, quiet); err != nil {
 		return err
 	}
-	return createProfileFunctionDirectories(tagDir, profiles, benchmarks, quiet)
+	return createSourceLinesDirectories(tagDir, profiles, benchmarks, quiet)
 }

--- a/engine/collect/layout_test.go
+++ b/engine/collect/layout_test.go
@@ -28,8 +28,8 @@ func TestCreateBenchDirectories(t *testing.T) {
 	}
 
 	cases := []struct {
-		name string
-		path string
+		name  string
+		path  string
 		isDir bool
 	}{
 		{"profiles root", filepath.Join(tagDir, workspace.ProfilesDir), true},

--- a/engine/collect/layout_test.go
+++ b/engine/collect/layout_test.go
@@ -30,12 +30,15 @@ func TestCreateBenchDirectories(t *testing.T) {
 	cases := []struct {
 		name string
 		path string
+		isDir bool
 	}{
-		{"bin root", filepath.Join(tagDir, workspace.ProfileBinDir)},
-		{"text root", filepath.Join(tagDir, workspace.ProfileTextDir)},
-		{"description", filepath.Join(tagDir, workspace.BenchDescriptionFileName)},
-		{"bin bench foo", filepath.Join(tagDir, workspace.ProfileBinDir, "BenchmarkFoo")},
-		{"text bench bar", filepath.Join(tagDir, workspace.ProfileTextDir, "BenchmarkBar")},
+		{"profiles root", filepath.Join(tagDir, workspace.ProfilesDir), true},
+		{"measurements root", filepath.Join(tagDir, workspace.MeasurementsDir), true},
+		{"hotspots root", filepath.Join(tagDir, workspace.HotspotsDir), true},
+		{"notes", filepath.Join(tagDir, workspace.TagNotesFileName), false},
+		{"profiles bench foo", filepath.Join(tagDir, workspace.ProfilesDir, "BenchmarkFoo"), true},
+		{"measurements bench bar", filepath.Join(tagDir, workspace.MeasurementsDir, "BenchmarkBar"), true},
+		{"hotspots bench bar", filepath.Join(tagDir, workspace.HotspotsDir, "BenchmarkBar"), true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -44,24 +47,27 @@ func TestCreateBenchDirectories(t *testing.T) {
 			if err != nil {
 				t.Fatalf("stat %s: %v", tc.path, err)
 			}
-			if !st.IsDir() && tc.name != "description" {
+			if tc.isDir && !st.IsDir() {
 				t.Fatalf("%s should be a directory", tc.path)
+			}
+			if !tc.isDir && st.IsDir() {
+				t.Fatalf("%s should be a file", tc.path)
 			}
 		})
 	}
 }
 
-func TestCreateProfileFunctionDirectories(t *testing.T) {
+func TestCreateSourceLinesDirectories(t *testing.T) {
 	t.Parallel()
 	tagDir := t.TempDir()
 	profiles := []string{"cpu", "memory"}
 	benchmarks := []string{"BenchmarkFoo"}
 
-	if err := createProfileFunctionDirectories(tagDir, profiles, benchmarks, false); err != nil {
+	if err := createSourceLinesDirectories(tagDir, profiles, benchmarks, false); err != nil {
 		t.Fatal(err)
 	}
 
-	want := filepath.Join(tagDir, "cpu"+workspace.FunctionsDirSuffix, "BenchmarkFoo")
+	want := filepath.Join(tagDir, workspace.SourceLinesDir, "cpu", "BenchmarkFoo")
 	if st, err := os.Stat(want); err != nil || !st.IsDir() {
 		t.Fatalf("expected directory %s: err=%v isDir=%v", want, err, st != nil && st.IsDir())
 	}
@@ -91,23 +97,28 @@ func TestSetupDirectories_createsTagLayout(t *testing.T) {
 		dir  bool
 	}{
 		{
-			"bin bench dir",
-			filepath.Join(layout.Root, workspace.ProfileBinDir, "BenchmarkFoo"),
+			"profiles bench dir",
+			filepath.Join(layout.Root, workspace.ProfilesDir, "BenchmarkFoo"),
 			true,
 		},
 		{
-			"text bench dir",
-			filepath.Join(layout.Root, workspace.ProfileTextDir, "BenchmarkFoo"),
+			"measurements bench dir",
+			filepath.Join(layout.Root, workspace.MeasurementsDir, "BenchmarkFoo"),
 			true,
 		},
 		{
-			"functions dir",
-			layout.FunctionsDir("cpu", "BenchmarkFoo"),
+			"hotspots bench dir",
+			filepath.Join(layout.Root, workspace.HotspotsDir, "BenchmarkFoo"),
 			true,
 		},
 		{
-			"memory functions dir",
-			layout.FunctionsDir("memory", "BenchmarkFoo"),
+			"source lines dir",
+			layout.SourceLinesDir("cpu", "BenchmarkFoo"),
+			true,
+		},
+		{
+			"memory source lines dir",
+			layout.SourceLinesDir("memory", "BenchmarkFoo"),
 			true,
 		},
 	}

--- a/engine/collect/manual.go
+++ b/engine/collect/manual.go
@@ -53,7 +53,7 @@ func processOneManualFile(runner tooling.Runner, fullBinaryPath string, layout w
 	stem := stemFromPath(fullBinaryPath)
 	filter := config.ResolveCollectionFilter(cfg, config.CollectionTargetManual(stem))
 
-	binDest := layout.Bin(benchName, profile)
+	binDest := layout.ProfileBinary(benchName, profile)
 	if err := copyProfileBinary(fullBinaryPath, binDest); err != nil {
 		return err
 	}
@@ -65,8 +65,11 @@ func processOneManualFile(runner tooling.Runner, fullBinaryPath string, layout w
 }
 
 func emitProfileArtifacts(runner tooling.Runner, binPath string, layout workspace.TagLayout, benchName, profile string) error {
-	textOut := layout.Text(benchName, profile)
-	return getProfileTextOutput(runner, binPath, textOut)
+	hotspotOut := layout.Hotspot(benchName, profile)
+	if err := os.MkdirAll(filepath.Dir(hotspotOut), workspace.PermDir); err != nil {
+		return fmt.Errorf("mkdir hotspots dest: %w", err)
+	}
+	return getProfileTextOutput(runner, binPath, hotspotOut)
 }
 
 func collectPerFunctionLists(runner tooling.Runner, layout workspace.TagLayout, benchName, profile, binPath string, functionFilter config.FunctionFilter) error {
@@ -75,7 +78,7 @@ func collectPerFunctionLists(runner tooling.Runner, layout workspace.TagLayout, 
 		return fmt.Errorf("extract function names: %w", err)
 	}
 
-	functionDir := layout.FunctionsDir(profile, benchName)
+	functionDir := layout.SourceLinesDir(profile, benchName)
 	if err = ensureDirExists(functionDir); err != nil {
 		return err
 	}
@@ -87,7 +90,7 @@ func collectPerFunctionLists(runner tooling.Runner, layout workspace.TagLayout, 
 
 func copyProfileBinary(src, dest string) error {
 	if err := os.MkdirAll(filepath.Dir(dest), workspace.PermDir); err != nil {
-		return fmt.Errorf("mkdir bin dest: %w", err)
+		return fmt.Errorf("mkdir profile dest: %w", err)
 	}
 	in, err := os.Open(src)
 	if err != nil {
@@ -96,7 +99,7 @@ func copyProfileBinary(src, dest string) error {
 	defer in.Close()
 	out, err := os.Create(dest)
 	if err != nil {
-		return fmt.Errorf("create bin dest: %w", err)
+		return fmt.Errorf("create profile dest: %w", err)
 	}
 	defer out.Close()
 	if _, err = io.Copy(out, in); err != nil {

--- a/engine/collect/options.go
+++ b/engine/collect/options.go
@@ -1,4 +1,5 @@
 // Package collect runs prof auto (go test) and prof manual (ingest) pipelines under bench/<tag>/.
+// Output domains: profiles/, measurements/, hotspots/, source_lines/, call_graphs/.
 package collect
 
 // AutoOptions configures RunAuto.

--- a/engine/collect/pipeline.go
+++ b/engine/collect/pipeline.go
@@ -86,12 +86,12 @@ func collectProfileFunctions(runner tooling.Runner, args *config.CollectionArgs,
 	}
 
 	for _, profile := range args.Profiles {
-		fnDir := layout.FunctionsDir(profile, args.BenchmarkName)
+		fnDir := layout.SourceLinesDir(profile, args.BenchmarkName)
 		if mkdirErr := os.MkdirAll(fnDir, workspace.PermDir); mkdirErr != nil {
 			return fmt.Errorf("failed to create output directory: %w", mkdirErr)
 		}
 
-		binPath := layout.Bin(args.BenchmarkName, profile)
+		binPath := layout.ProfileBinary(args.BenchmarkName, profile)
 		listEntries, listErr := parser.GetFunctionListEntriesV2(binPath, args.BenchmarkConfig)
 		if listErr != nil {
 			return fmt.Errorf("failed to extract function names: %w", listErr)

--- a/engine/collect/profiles.go
+++ b/engine/collect/profiles.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 
 	"github.com/AlexsanderHamir/prof/engine/tooling"
 	"github.com/AlexsanderHamir/prof/internal/termui"
@@ -20,7 +21,7 @@ func processProfiles(runner tooling.Runner, benchmarkName string, profiles []str
 	var processed []string
 
 	for _, profile := range profiles {
-		profileFile := layout.Bin(benchmarkName, profile)
+		profileFile := layout.ProfileBinary(benchmarkName, profile)
 		if _, statErr := os.Stat(profileFile); statErr != nil {
 			if errors.Is(statErr, os.ErrNotExist) {
 				warnMissingProfile(session, profileFile)
@@ -29,18 +30,21 @@ func processProfiles(runner tooling.Runner, benchmarkName string, profiles []str
 			return nil, fmt.Errorf("failed to stat profile file %s: %w", profileFile, statErr)
 		}
 
-		outputFile := layout.Text(benchmarkName, profile)
-		fnDir := layout.FunctionsDir(profile, benchmarkName)
+		outputFile := layout.Hotspot(benchmarkName, profile)
+		sourceLinesDir := layout.SourceLinesDir(profile, benchmarkName)
 
 		if textErr := getProfileTextOutput(runner, profileFile, outputFile); textErr != nil {
-			return nil, fmt.Errorf("failed to generate text profile for %s: %w", profile, textErr)
+			return nil, fmt.Errorf("failed to generate hotspot summary for %s: %w", profile, textErr)
 		}
 
-		if mkdirErr := os.MkdirAll(fnDir, workspace.PermDir); mkdirErr != nil {
-			return nil, fmt.Errorf("failed to create profile functions directory: %w", mkdirErr)
+		if mkdirErr := os.MkdirAll(sourceLinesDir, workspace.PermDir); mkdirErr != nil {
+			return nil, fmt.Errorf("failed to create source_lines directory: %w", mkdirErr)
 		}
 
-		pngPath := layout.PNG(profile, benchmarkName)
+		pngPath := layout.CallGraph(profile, benchmarkName)
+		if mkdirErr := os.MkdirAll(filepath.Dir(pngPath), workspace.PermDir); mkdirErr != nil {
+			return nil, fmt.Errorf("failed to create call_graphs directory: %w", mkdirErr)
+		}
 		if pngErr := getPNGOutput(runner, profileFile, pngPath); pngErr != nil {
 			warnSkippedPNG(session, profile, benchmarkName, pngErr)
 		}

--- a/engine/collect/profiles_test.go
+++ b/engine/collect/profiles_test.go
@@ -28,9 +28,9 @@ func setupProcessProfilesEnv(t *testing.T, tag, bench string, profiles []string)
 	return layout, fixture
 }
 
-func copyFixtureToBin(t *testing.T, layout workspace.TagLayout, bench, profile, src string) {
+func copyFixtureToProfile(t *testing.T, layout workspace.TagLayout, bench, profile, src string) {
 	t.Helper()
-	dst := layout.Bin(bench, profile)
+	dst := layout.ProfileBinary(bench, profile)
 	if err := os.MkdirAll(filepath.Dir(dst), workspace.PermDir); err != nil {
 		t.Fatal(err)
 	}
@@ -49,7 +49,7 @@ func TestProcessProfiles_skipsMissingBinary(t *testing.T) {
 		bench = "BenchmarkFoo"
 	)
 	layout, fixture := setupProcessProfilesEnv(t, tag, bench, []string{"cpu", "memory"})
-	copyFixtureToBin(t, layout, bench, "cpu", fixture)
+	copyFixtureToProfile(t, layout, bench, "cpu", fixture)
 
 	runner := &tooling.FakeRunner{
 		Out: [][]byte{[]byte("flat profile text"), []byte("png-bytes")},
@@ -82,7 +82,7 @@ func TestProcessProfiles_continuesOnPNGFailure(t *testing.T) {
 		bench = "BenchmarkFoo"
 	)
 	layout, fixture := setupProcessProfilesEnv(t, tag, bench, []string{"cpu"})
-	copyFixtureToBin(t, layout, bench, "cpu", fixture)
+	copyFixtureToProfile(t, layout, bench, "cpu", fixture)
 
 	runner := &tooling.FakeRunner{
 		Out: [][]byte{[]byte("flat profile text")},
@@ -95,7 +95,7 @@ func TestProcessProfiles_continuesOnPNGFailure(t *testing.T) {
 	if len(processed) != 1 || processed[0] != "cpu" {
 		t.Fatalf("processed: %#v", processed)
 	}
-	if _, statErr := os.Stat(layout.Text(bench, "cpu")); statErr != nil {
-		t.Fatalf("expected text profile: %v", statErr)
+	if _, statErr := os.Stat(layout.Hotspot(bench, "cpu")); statErr != nil {
+		t.Fatalf("expected hotspot summary: %v", statErr)
 	}
 }

--- a/internal/config/template.go
+++ b/internal/config/template.go
@@ -22,13 +22,13 @@ func ExampleTemplate(modulePath string) string {
 {
     "version": 1,
 
-    // collection — which functions prof keeps when saving CPU/memory profiles after benchmarks.
+    // collection — which functions prof keeps when saving line-level extracts under source_lines/<profile>/.
     // Docs: `+docSiteBase+`/configure/#collection
     //       `+docSiteBase+`/collect/#artifact-layout-under-benchtag
     "collection": {
         "defaults": {
             // include_prefixes: if set, only functions whose full pprof symbol contains one of these
-            // substrings (usually your module import path) are saved into per-function extracts.
+            // substrings (usually your module import path) are saved under source_lines/<profile>/<benchmark>/.
             // Example: "`+includeExample+`" or "`+includeExample+`/internal/foo"
             // Empty [] keeps every function (including stdlib) — usually too broad.
             "include_prefixes": [

--- a/internal/workspace/const.go
+++ b/internal/workspace/const.go
@@ -1,20 +1,24 @@
 package workspace
 
 // Path and permission constants for bench/<tag>/ layout.
+// Domains follow domain/<benchmark>/artifact (profile kind is a segment under source_lines/ and call_graphs/).
 const (
-	MainDirOutput               = "bench"
-	ProfileTextDir              = "text"
-	ProfileBinDir               = "bin"
-	PermDir                     = 0o755
-	PermFile                    = 0o644
-	FunctionsDirSuffix          = "_functions"
-	TextExtension               = "txt"
-	ExpectedTestSuffix          = ".test"
-	ProfileArtifactExtension    = "out"
-	BenchDescriptionFileName    = "description.txt"
-	BenchDescriptionPlaceholder = "The explanation for this profilling session goes here"
-	GoBinaryName                = "go"
-	GoTestSubcommand            = "test"
+	MainDirOutput            = "bench"
+	ProfilesDir              = "profiles"
+	MeasurementsDir          = "measurements"
+	HotspotsDir              = "hotspots"
+	SourceLinesDir           = "source_lines"
+	CallGraphsDir            = "call_graphs"
+	MeasurementRunFile       = "run.txt"
+	TagNotesFileName         = "notes.txt"
+	TagNotesPlaceholder      = "The explanation for this profiling session goes here"
+	PermDir                  = 0o755
+	PermFile                 = 0o644
+	TextExtension            = "txt"
+	ExpectedTestSuffix       = ".test"
+	ProfileArtifactExtension = "out"
+	GoBinaryName             = "go"
+	GoTestSubcommand         = "test"
 )
 
 // InfoCollectionSuccess is logged when auto collection completes.

--- a/internal/workspace/doc.go
+++ b/internal/workspace/doc.go
@@ -1,2 +1,11 @@
 // Package workspace defines bench/<tag>/ layout paths and tag lifecycle helpers.
+//
+// Artifact domains under each tag describe the data they hold (domain/benchmark/artifact):
+//
+//   - profiles/      — raw pprof profile binaries (e.g. cpu.out)
+//   - measurements/  — go test benchmark run stats (run.txt)
+//   - hotspots/      — function-ranked stack summaries per profile (cpu.txt)
+//   - source_lines/  — line-level pprof -list extracts per profile kind
+//   - call_graphs/   — optional Graphviz PNG call graphs per profile kind
+//   - notes.txt      — tag-level note at the tag root
 package workspace

--- a/internal/workspace/layout.go
+++ b/internal/workspace/layout.go
@@ -38,34 +38,34 @@ func TagDirFromCWD(tag string) (string, error) {
 	return l.Root, nil
 }
 
-// Bin returns the profile binary path for a benchmark and profile kind.
-func (l TagLayout) Bin(bench, profile string) string {
-	return filepath.Join(l.Root, ProfileBinDir, bench, fmt.Sprintf("%s_%s.%s", bench, profile, ProfileArtifactExtension))
+// ProfileBinary returns the raw pprof profile path for a benchmark and profile kind.
+func (l TagLayout) ProfileBinary(bench, profile string) string {
+	return filepath.Join(l.Root, ProfilesDir, bench, fmt.Sprintf("%s.%s", profile, ProfileArtifactExtension))
 }
 
-// Text returns the flat text profile path for a benchmark and profile kind.
-func (l TagLayout) Text(bench, profile string) string {
-	return filepath.Join(l.Root, ProfileTextDir, bench, fmt.Sprintf("%s_%s.%s", bench, profile, TextExtension))
+// Hotspot returns the function-ranked stack summary path for a benchmark and profile kind.
+func (l TagLayout) Hotspot(bench, profile string) string {
+	return filepath.Join(l.Root, HotspotsDir, bench, fmt.Sprintf("%s.%s", profile, TextExtension))
 }
 
-// BenchText returns the combined benchmark text listing path.
-func (l TagLayout) BenchText(bench string) string {
-	return filepath.Join(l.Root, ProfileTextDir, bench, fmt.Sprintf("%s.%s", bench, TextExtension))
+// Measurement returns the go test benchmark run transcript path.
+func (l TagLayout) Measurement(bench string) string {
+	return filepath.Join(l.Root, MeasurementsDir, bench, MeasurementRunFile)
 }
 
-// FunctionsDir returns the per-function pprof list output directory.
-func (l TagLayout) FunctionsDir(profile, bench string) string {
-	return filepath.Join(l.Root, profile+FunctionsDirSuffix, bench)
+// SourceLinesDir returns the per-function pprof -list output directory.
+func (l TagLayout) SourceLinesDir(profile, bench string) string {
+	return filepath.Join(l.Root, SourceLinesDir, profile, bench)
 }
 
-// PNG returns the Graphviz PNG visualization path for a profile.
-func (l TagLayout) PNG(profile, bench string) string {
-	return filepath.Join(l.FunctionsDir(profile, bench), fmt.Sprintf("%s_%s.png", bench, profile))
+// CallGraph returns the Graphviz call-graph PNG path for a profile.
+func (l TagLayout) CallGraph(profile, bench string) string {
+	return filepath.Join(l.Root, CallGraphsDir, profile, bench, fmt.Sprintf("%s.png", profile))
 }
 
-// ResolveBin returns the binary profile path when it exists and is readable.
-func (l TagLayout) ResolveBin(bench, profile string) (string, error) {
-	p := l.Bin(bench, profile)
+// ResolveProfileBinary returns the binary profile path when it exists and is readable.
+func (l TagLayout) ResolveProfileBinary(bench, profile string) (string, error) {
+	p := l.ProfileBinary(bench, profile)
 	if _, err := os.Stat(p); err != nil {
 		return "", err
 	}

--- a/internal/workspace/layout_test.go
+++ b/internal/workspace/layout_test.go
@@ -20,10 +20,31 @@ func TestTagLayout_paths(t *testing.T) {
 		got  string
 		want string
 	}{
-		{"bin", l.Bin("BenchmarkFoo", "cpu"), filepath.Join(root, "bench", "v1", "bin", "BenchmarkFoo", "BenchmarkFoo_cpu.out")},
-		{"text", l.Text("BenchmarkFoo", "cpu"), filepath.Join(root, "bench", "v1", "text", "BenchmarkFoo", "BenchmarkFoo_cpu.txt")},
-		{"functions", l.FunctionsDir("cpu", "BenchmarkFoo"), filepath.Join(root, "bench", "v1", "cpu_functions", "BenchmarkFoo")},
-		{"bench text", l.BenchText("BenchmarkFoo"), filepath.Join(root, "bench", "v1", "text", "BenchmarkFoo", "BenchmarkFoo.txt")},
+		{
+			"profile binary",
+			l.ProfileBinary("BenchmarkFoo", "cpu"),
+			filepath.Join(root, "bench", "v1", "profiles", "BenchmarkFoo", "cpu.out"),
+		},
+		{
+			"hotspot",
+			l.Hotspot("BenchmarkFoo", "cpu"),
+			filepath.Join(root, "bench", "v1", "hotspots", "BenchmarkFoo", "cpu.txt"),
+		},
+		{
+			"source lines",
+			l.SourceLinesDir("cpu", "BenchmarkFoo"),
+			filepath.Join(root, "bench", "v1", "source_lines", "cpu", "BenchmarkFoo"),
+		},
+		{
+			"measurement",
+			l.Measurement("BenchmarkFoo"),
+			filepath.Join(root, "bench", "v1", "measurements", "BenchmarkFoo", "run.txt"),
+		},
+		{
+			"call graph",
+			l.CallGraph("cpu", "BenchmarkFoo"),
+			filepath.Join(root, "bench", "v1", "call_graphs", "cpu", "BenchmarkFoo", "cpu.png"),
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -35,11 +56,11 @@ func TestTagLayout_paths(t *testing.T) {
 	}
 }
 
-func TestTagLayout_ResolveBin_missing(t *testing.T) {
+func TestTagLayout_ResolveProfileBinary_missing(t *testing.T) {
 	t.Parallel()
 	l := workspace.NewTagLayout(t.TempDir(), "t")
-	if _, err := l.ResolveBin("B", "cpu"); err == nil {
-		t.Fatal("expected error for missing bin")
+	if _, err := l.ResolveProfileBinary("B", "cpu"); err == nil {
+		t.Fatal("expected error for missing profile binary")
 	}
 }
 

--- a/prof_web_doc/docs/collect.md
+++ b/prof_web_doc/docs/collect.md
@@ -52,19 +52,21 @@ Each run writes a single tag directory, `bench/<tag>/`, under your [module root]
 #### How that helps
 
 - Open profiles in `pprof`: binary and text files under each tag share predictable paths.
-- Share context: zip `bench/<tag>/` or attach key `text/` files to an issue or PR so others see the same profile view you did.
-- Re-open in pprof: point `go tool pprof` at `bin/<BenchmarkName>/<BenchmarkName>_<profile>.out` for ad-hoc queries on the stored binary.
+- Share context: zip `bench/<tag>/` or attach key `hotspots/` or `measurements/` files to an issue or PR so others see the same profile view you did.
+- Re-open in pprof: point `go tool pprof` at `profiles/<BenchmarkName>/<profile>.out` for ad-hoc queries on the stored binary.
 
 ### Artifact layout under `bench/<tag>/` { #artifact-layout-under-benchtag }
 
 | Location | What you get | Typical use |
 | -------- | ------------- | ----------- |
-| `description.txt` | Short tag-level note (placeholder until you edit it). | Record why this run exists (branch, experiment, machine). |
-| `bin/<BenchmarkName>/` | One `BenchmarkName_<profile>.out` per profile type collected. | Source of truth for `pprof`; required for regenerating text and PNGs. |
-| `text/<BenchmarkName>/` | For each profile: `BenchmarkName_<profile>.txt` (flat listing). | Read, grep, or diff stacks. |
-| `<profile>_functions/<BenchmarkName>/` | Per-function text files for symbols in scope, plus optional `BenchmarkName_<profile>.png` when Graphviz is available. | Deep dive on specific functions; optional call-graph PNG for presentations. |
+| `notes.txt` | Short tag-level note (placeholder until you edit it). | Record why this run exists (branch, experiment, machine). |
+| `profiles/<BenchmarkName>/` | One `<profile>.out` per profile type collected. | Source of truth for `pprof`; required for regenerating hotspots and PNGs. |
+| `measurements/<BenchmarkName>/` | `run.txt` with `go test -bench` output (ns/op, allocs). | Compare throughput across runs. |
+| `hotspots/<BenchmarkName>/` | For each profile: `<profile>.txt` (function-ranked stacks). | Read, grep, or diff stacks. |
+| `source_lines/<profile>/<BenchmarkName>/` | Per-function text files for symbols in scope. | Deep dive on specific functions with line attribution. |
+| `call_graphs/<profile>/<BenchmarkName>/` | Optional `<profile>.png` when Graphviz is available. | Call-graph PNG for presentations. |
 
-Exact names and suffixes are defined in the implementation (`internal` constants and `engine/benchmark` path helpers); the table above matches the usual `prof auto` and `prof manual` layout.
+Exact paths are defined in [`internal/workspace.TagLayout`](https://github.com/AlexsanderHamir/prof/blob/main/internal/workspace/layout.go); the table above matches the usual `prof auto` and `prof manual` layout.
 
 ## `prof manual` { #prof-manual }
 
@@ -82,7 +84,7 @@ Per-file collection filters use `collection.manual_profiles` in `prof.json`. Key
 
 ## Testing / verify
 
-After `prof auto`, you should see `bench/<tag>/bin/<BenchmarkName>/` containing `BenchmarkName_<profile>.out` for each profile you requested, and matching files under `text/<BenchmarkName>/`.
+After `prof auto`, you should see `bench/<tag>/profiles/<BenchmarkName>/` containing `<profile>.out` for each profile you requested, `measurements/<BenchmarkName>/run.txt`, and matching files under `hotspots/<BenchmarkName>/`.
 
 If `go test` fails, Prof exits non-zero. Fix the test failure first. For PNG or Graphviz issues, see [Troubleshooting](troubleshooting.md#graphviz-png-errors).
 

--- a/prof_web_doc/docs/configure.md
+++ b/prof_web_doc/docs/configure.md
@@ -102,7 +102,7 @@ Unset fields inherit from `collection.defaults`.
 
 ### Manual profile overrides { #collection-manual-profiles }
 
-Use `collection.manual_profiles` for profiles ingested by `prof manual`. The key is the profile file **stem** under `bench/<tag>/bin/`, e.g. `BenchmarkFoo_cpu` for `BenchmarkFoo_cpu.out`:
+Use `collection.manual_profiles` for profiles ingested by `prof manual`. The key is the profile file **stem** from the path you pass on the command line, e.g. `BenchmarkFoo_cpu` for `BenchmarkFoo_cpu.out` (stored as `profiles/BenchmarkFoo/cpu.out`):
 
 ```json
 "manual_profiles": {

--- a/prof_web_doc/docs/quickstart.md
+++ b/prof_web_doc/docs/quickstart.md
@@ -25,7 +25,7 @@ prof ui
 
 In the menu, choose Collect Profiles, pick your benchmarks and profile types, and enter a tag such as `baseline`.
 
-Verify: you should see `bench/baseline/` with `bin/` and `text/` populated.
+Verify: you should see `bench/baseline/` with `profiles/`, `measurements/`, and `hotspots/` populated.
 
 If the UI does not start, your environment may not expose a TTY. Use Path B or see [Troubleshooting](troubleshooting.md#prof-ui-or-prof-tui-fails-in-ci-or-ides).
 
@@ -37,7 +37,7 @@ prof auto --benchmarks "BenchmarkExample" --profiles "cpu,memory,mutex,block" --
 
 Verify:
 
-- On disk: `bench/baseline/` contains `bin/BenchmarkExample/` and `text/BenchmarkExample/`.
+- On disk: `bench/baseline/` contains `profiles/BenchmarkExample/`, `measurements/BenchmarkExample/`, and `hotspots/BenchmarkExample/`.
 
 ## If something fails
 

--- a/prof_web_doc/docs/tui.md
+++ b/prof_web_doc/docs/tui.md
@@ -35,7 +35,7 @@ Navigation: arrow keys; Space toggles in multi-select; type to filter long lists
 
 ## Testing / verify
 
-After finishing `prof tui` or the collect path in `prof ui`, confirm `bench/<tag>/` exists with `bin/` and `text/` populated.
+After finishing `prof tui` or the collect path in `prof ui`, confirm `bench/<tag>/` exists with `profiles/`, `measurements/`, and `hotspots/` populated.
 
 ## Next steps
 

--- a/prof_web_doc/docs/workspace.md
+++ b/prof_web_doc/docs/workspace.md
@@ -17,14 +17,17 @@ Prof uses your current working directory to find the Go module and to write `ben
 
 ## Directory layout under `bench/<tag>/`
 
-Using Prof creates a `bench/` tree next to your module, one folder per run (tag). That layout is how `go tool pprof` and per-function extracts find the same data.
+Using Prof creates a `bench/` tree next to your module, one folder per run (tag). Domains describe the data they hold (`domain/<BenchmarkName>/artifact`).
 
 | Path | What it is |
 | ---- | ---------- |
-| `bench/<tag>/` | One labeled run: profiles, text extracts, and optional PNGs for that tag. |
-| `bench/<tag>/bin/<BenchmarkName>/` | Binary profiles (`.out`), the durable source for `go tool pprof`. |
-| `bench/<tag>/text/<BenchmarkName>/` | Human-readable profile listings (flat text). |
-| `bench/<tag>/<profile>_functions/<BenchmarkName>/` | Per-function extracts when configured; optional call-graph PNGs if Graphviz is installed. |
+| `bench/<tag>/` | One labeled run: profiles, measurements, hotspots, and optional extracts for that tag. |
+| `bench/<tag>/profiles/<BenchmarkName>/` | Raw pprof profile binaries (`.out`); durable source for `go tool pprof`. |
+| `bench/<tag>/measurements/<BenchmarkName>/` | `go test` benchmark run stats (`run.txt`: ns/op, allocs). |
+| `bench/<tag>/hotspots/<BenchmarkName>/` | Function-ranked stack summaries per profile (`cpu.txt`, `memory.txt`). |
+| `bench/<tag>/source_lines/<profile>/<BenchmarkName>/` | Per-function `pprof -list` extracts when configured. |
+| `bench/<tag>/call_graphs/<profile>/<BenchmarkName>/` | Optional Graphviz PNG call graphs when installed. |
+| `bench/<tag>/notes.txt` | Short tag-level note (placeholder until you edit it). |
 | `prof.json` | Active config next to `go.mod` after `prof config init` or **Manage configuration** in `prof ui`. |
 | `prof.json.example` | Commented reference (not loaded); copy optional sections into `prof.json`. See [Configure — generated files](configure.md#generated-files). |
 
@@ -39,7 +42,7 @@ Both files live beside `go.mod` at the module root:
 
 ## Testing / verify
 
-From the module root, after a successful collect, you should see a new directory `bench/<your-tag>/` with at least `bin/<BenchmarkName>/` and `text/<BenchmarkName>/` populated for the profiles you enabled.
+From the module root, after a successful collect, you should see a new directory `bench/<your-tag>/` with at least `profiles/<BenchmarkName>/`, `measurements/<BenchmarkName>/`, and `hotspots/<BenchmarkName>/` populated for the profiles you enabled.
 
 If `bench/` never appears, see [Troubleshooting](troubleshooting.md#wrong-directory-or-no-bench-folder).
 

--- a/tests/assert.go
+++ b/tests/assert.go
@@ -1,7 +1,6 @@
 package tests
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -67,31 +66,34 @@ func checkOutput(t *testing.T, envPath string, testArgs *TestArgs) {
 	tagPath := filepath.Join(benchPath, tag)
 	checkDirectory(t, tagPath, tag)
 
-	binPath := filepath.Join(tagPath, workspace.ProfileBinDir)
-	textPath := filepath.Join(tagPath, workspace.ProfileTextDir)
-	binBenchPath := filepath.Join(binPath, benchName)
-	textBenchPath := filepath.Join(textPath, benchName)
+	profilesPath := filepath.Join(tagPath, workspace.ProfilesDir)
+	measurementsPath := filepath.Join(tagPath, workspace.MeasurementsDir)
+	hotspotsPath := filepath.Join(tagPath, workspace.HotspotsDir)
+	profilesBenchPath := filepath.Join(profilesPath, benchName)
+	measurementsBenchPath := filepath.Join(measurementsPath, benchName)
+	hotspotsBenchPath := filepath.Join(hotspotsPath, benchName)
 
 	configDoesntApply := false
 
-	checkDirectory(t, binPath, "bin directory")
-	checkDirectory(t, binBenchPath, "benchmark directory inside of bin")
-	checkDirectoryFiles(t, binBenchPath, "bin files inside of benchmark directory", expectedNumberOfFiles, expectNonSpecifiedFiles, configDoesntApply, specifiedFiles)
+	checkDirectory(t, profilesPath, "profiles directory")
+	checkDirectory(t, profilesBenchPath, "benchmark directory inside profiles")
+	checkDirectoryFiles(t, profilesBenchPath, "profile files inside benchmark directory", expectedNumberOfFiles, expectNonSpecifiedFiles, configDoesntApply, specifiedFiles)
 
-	checkDirectory(t, textPath, "text directory")
-	checkDirectory(t, textBenchPath, "benchmark directory inside of text")
-	checkDirectoryFiles(t, textBenchPath, "text files inside of benchmark directory", expectedNumberOfFiles, expectNonSpecifiedFiles, configDoesntApply, specifiedFiles)
+	checkDirectory(t, measurementsPath, "measurements directory")
+	checkDirectory(t, measurementsBenchPath, "benchmark directory inside measurements")
+	checkDirectoryFiles(t, measurementsBenchPath, "measurement files inside benchmark directory", 1, expectNonSpecifiedFiles, configDoesntApply, specifiedFiles)
+
+	checkDirectory(t, hotspotsPath, "hotspots directory")
+	checkDirectory(t, hotspotsBenchPath, "benchmark directory inside hotspots")
+	checkDirectoryFiles(t, hotspotsBenchPath, "hotspot files inside benchmark directory", len(expectedProfiles), expectNonSpecifiedFiles, configDoesntApply, specifiedFiles)
 
 	for _, profile := range expectedProfiles {
-		profileFunctionsDir := fmt.Sprintf("%s%s", profile, workspace.FunctionsDirSuffix)
-		profileFunctionsPath := filepath.Join(tagPath, profileFunctionsDir)
-		checkDirectory(t, profileFunctionsPath, "profile functions directory e.g cpu_functions")
-
-		benchDir := filepath.Join(profileFunctionsPath, benchName)
-		checkDirectory(t, benchDir, "benchmark directory inside profile functions directory e.g cpu_functions/BenchmarkName")
+		sourceLinesBenchPath := filepath.Join(tagPath, workspace.SourceLinesDir, profile, benchName)
+		checkDirectory(t, filepath.Join(tagPath, workspace.SourceLinesDir, profile), "source_lines/"+profile+" directory")
+		checkDirectory(t, sourceLinesBenchPath, "benchmark directory inside source_lines/"+profile)
 
 		// Per-function dir size depends on filter sampling jitter so we don't enforce a count.
-		checkDirectoryFiles(t, benchDir, "individual function files inside benchmark directory", 0, expectNonSpecifiedFiles, withConfig, specifiedFiles)
+		checkDirectoryFiles(t, sourceLinesBenchPath, "individual function files inside benchmark directory", 0, expectNonSpecifiedFiles, withConfig, specifiedFiles)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Replace `bin`/`text`/`*_functions` with data-descriptive domains: `profiles`, `measurements`, `hotspots`, `source_lines`, and `call_graphs`
- Shorten in-benchmark filenames (`cpu.out`, `run.txt`, `cpu.txt`) now that the domain carries context
- Rename tag note file from `description.txt` to `notes.txt`

**Breaking change:** existing on-disk `bench/<tag>/` trees are not migrated. Re-run `prof auto` or `prof manual` to populate the new layout.

## Test plan

- [x] `go test ./...`
- [ ] Manual smoke: `prof auto` and confirm `bench/<tag>/` has `profiles/`, `measurements/`, `hotspots/`, and `source_lines/` populated

Made with [Cursor](https://cursor.com)