### PR TITLE
feat(termui): stage-scoped collect progress and survey handoff

### DIFF
--- a/cli/cmd_ui.go
+++ b/cli/cmd_ui.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/AlexsanderHamir/prof/internal/app"
+	"github.com/AlexsanderHamir/prof/internal/termui"
 	"github.com/AlexsanderHamir/prof/internal/tui"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
@@ -73,7 +74,7 @@ func runUILauncherOnce(svc *app.Services) error {
 }
 
 func finishUIWorkflow(runErr error) error {
-	if runErr != nil {
+	if runErr != nil && !termui.ErrorWasStaged(runErr) {
 		fmt.Fprintf(os.Stderr, "%v\n", runErr)
 	}
 	if err := promptReturnToHub(); err != nil {

--- a/engine/collect/artifacts_pprof.go
+++ b/engine/collect/artifacts_pprof.go
@@ -88,16 +88,25 @@ func writeFunctionListPprof(runner tooling.Runner, shortStem, fullSymbol, binary
 }
 
 func getFunctionsOutput(runner tooling.Runner, entries []parser.FunctionListEntry, binaryPath, basePath string, session *termui.Session) error {
+	const maxPerFunctionWarnings = 3
+	var skipped int
+
 	for _, e := range entries {
 		out := filepath.Join(basePath, e.OutputStem+"."+workspace.TextExtension)
 		if err := writeFunctionListPprof(runner, e.OutputStem, e.FullSymbol, binaryPath, out); err != nil {
-			if session.Interactive() {
-				session.Warn(fmt.Sprintf("skipping per-function pprof list for %s: %v", e.OutputStem, err))
+			skipped++
+			if session != nil && session.Interactive() {
+				if skipped <= maxPerFunctionWarnings {
+					session.Warn(fmt.Sprintf("skipping per-function pprof list for %s: %v", e.OutputStem, err))
+				}
 			} else {
 				slog.Warn("skipping per-function pprof list", "function", e.OutputStem, "binary", binaryPath, "err", err)
 			}
 			continue
 		}
+	}
+	if skipped > maxPerFunctionWarnings && session != nil && session.Interactive() {
+		session.Warn(fmt.Sprintf("… and %d more functions skipped", skipped-maxPerFunctionWarnings))
 	}
 	return nil
 }

--- a/engine/collect/entry.go
+++ b/engine/collect/entry.go
@@ -54,9 +54,9 @@ func RunAuto(runner tooling.Runner, opts AutoOptions) error {
 			}
 			return setupDirectories(opts.Tag, opts.Benchmarks, opts.Profiles, true)
 		}); prepErr != nil {
-			return fmt.Errorf("failed to setup directories: %w", prepErr)
+			return finalizeInteractiveErr(session, fmt.Errorf("failed to setup directories: %w", prepErr))
 		}
-		return runBenchAndGetProfiles(runner, autoArgs, cfg, session)
+		return finalizeInteractiveErr(session, runBenchAndGetProfiles(runner, autoArgs, cfg, session))
 	}
 
 	if cfgMissing {

--- a/engine/collect/entry.go
+++ b/engine/collect/entry.go
@@ -44,6 +44,7 @@ func RunAuto(runner tooling.Runner, opts AutoOptions) error {
 	}
 
 	if session.Interactive() {
+		session.BeginCollect()
 		if prepErr := session.RunWhile(termui.Progress{Phase: termui.PhasePrepare}, func() error {
 			if cfgMissing {
 				session.Warn("No prof.json found; proceeding without function filters (run prof config init to add one).")

--- a/engine/collect/pipeline.go
+++ b/engine/collect/pipeline.go
@@ -13,6 +13,13 @@ import (
 	"github.com/AlexsanderHamir/prof/parser"
 )
 
+func finalizeInteractiveErr(session *termui.Session, err error) error {
+	if err == nil || session == nil || !session.Interactive() || !session.ErrorDisplayed() {
+		return err
+	}
+	return termui.StagedDisplay(err)
+}
+
 func runBenchAndGetProfiles(runner tooling.Runner, autoArgs *config.AutoArgs, cfg *config.Config, session *termui.Session) error {
 	if !session.Interactive() {
 		slog.Info("Starting benchmark pipeline...")
@@ -38,7 +45,7 @@ func runBenchAndGetProfiles(runner tooling.Runner, autoArgs *config.AutoArgs, cf
 		if err := session.RunWhile(base.WithPhase(termui.PhaseRunBenchmark).WithDetail(countDetail), func() error {
 			return runBenchmark(runner, benchmarkName, autoArgs.Profiles, autoArgs.Count, autoArgs.Tag)
 		}); err != nil {
-			return fmt.Errorf("failed to run %s: %w", benchmarkName, err)
+			return finalizeInteractiveErr(session, fmt.Errorf("failed to run %s: %w", benchmarkName, err))
 		}
 
 		filter := config.ResolveCollectionFilter(cfg, config.CollectionTargetAuto(benchmarkName))
@@ -52,7 +59,7 @@ func runBenchAndGetProfiles(runner tooling.Runner, autoArgs *config.AutoArgs, cf
 			profilesReady, procErr = processProfiles(runner, benchmarkName, autoArgs.Profiles, autoArgs.Tag, session)
 			return procErr
 		}); err != nil {
-			return fmt.Errorf("failed to process profiles for %s: %w", benchmarkName, err)
+			return finalizeInteractiveErr(session, fmt.Errorf("failed to process profiles for %s: %w", benchmarkName, err))
 		}
 
 		if !session.Interactive() {
@@ -67,7 +74,7 @@ func runBenchAndGetProfiles(runner tooling.Runner, autoArgs *config.AutoArgs, cf
 		if err := session.RunWhile(base.WithPhase(termui.PhaseCollectFunctionProfiles), func() error {
 			return collectProfileFunctions(runner, args, session)
 		}); err != nil {
-			return fmt.Errorf("failed to collect function profiles for %s: %w", benchmarkName, err)
+			return finalizeInteractiveErr(session, fmt.Errorf("failed to collect function profiles for %s: %w", benchmarkName, err))
 		}
 
 		if !session.Interactive() {

--- a/internal/termui/progress.go
+++ b/internal/termui/progress.go
@@ -175,6 +175,22 @@ func (s *Session) BeginBenchmark(index, total int, name string) {
 
 var dotSpinner = spinner.Dot
 
+// ErrStagedDisplay marks an error whose message was already printed under a stage header.
+var ErrStagedDisplay = errors.New("termui: error rendered under stage")
+
+// StagedDisplay wraps err when the interactive session already showed it under a stage.
+func StagedDisplay(err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("%w: %w", ErrStagedDisplay, err)
+}
+
+// ErrorWasStaged reports whether err was wrapped with ErrStagedDisplay.
+func ErrorWasStaged(err error) bool {
+	return errors.Is(err, ErrStagedDisplay)
+}
+
 // RunWhile runs fn while showing a persistent spinner when the session is interactive.
 func (s *Session) RunWhile(p Progress, fn func() error) error {
 	if fn == nil {

--- a/internal/termui/progress.go
+++ b/internal/termui/progress.go
@@ -67,24 +67,24 @@ func (p Progress) WithDetail(detail string) Progress {
 //
 // The step line updates in place while running (spinner), then becomes ✓ when done.
 type Session struct {
-	w           io.Writer
-	fd          int
-	interactive bool
+	w                 io.Writer
+	fd                int
+	interactive       bool
 	termWidthOverride int // tests only; when > 0, used instead of terminal size
 
-	mu                sync.Mutex
-	stageActive       bool
-	headerLocked      bool
-	detailLines       int
-	warnCount         int
+	mu                 sync.Mutex
+	stageActive        bool
+	headerLocked       bool
+	detailLines        int
+	warnCount          int
 	errorDetailEmitted bool
-	errorDisplayed    bool
-	runningLabel      string
-	warnPrefix        string
-	lastFrame         string
-	spinnerStop       chan struct{}
-	spinnerDone       sync.WaitGroup
-	benchmarksStarted int
+	errorDisplayed     bool
+	runningLabel       string
+	warnPrefix         string
+	lastFrame          string
+	spinnerStop        chan struct{}
+	spinnerDone        sync.WaitGroup
+	benchmarksStarted  int
 }
 
 // NewSession reports whether w/fd is an interactive terminal.

--- a/internal/termui/progress.go
+++ b/internal/termui/progress.go
@@ -133,6 +133,22 @@ func phasePrefixes(phase Phase) (linePrefix, warnPrefix string) {
 	return "  ", "      "
 }
 
+// BeginCollect prints a section break before the prepare stage (interactive only).
+func (s *Session) BeginCollect() {
+	if s == nil || !s.interactive {
+		return
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	fmt.Fprintln(s.w)
+	fmt.Fprintln(s.w, BenchmarkTitleStyle.Render(CollectSectionTitle))
+	width := s.termWidth()
+	fmt.Fprintln(s.w, SectionRuleStyle.Render(strings.Repeat("─", width)))
+	fmt.Fprintln(s.w)
+}
+
 // BeginBenchmark prints a section header before the three steps for one benchmark.
 func (s *Session) BeginBenchmark(index, total int, name string) {
 	if s == nil || !s.interactive {

--- a/internal/termui/progress.go
+++ b/internal/termui/progress.go
@@ -76,6 +76,8 @@ type Session struct {
 	headerLocked      bool
 	detailLines       int
 	warnCount         int
+	errorDetailEmitted bool
+	errorDisplayed    bool
 	runningLabel      string
 	warnPrefix        string
 	lastFrame         string
@@ -187,6 +189,7 @@ func (s *Session) RunWhile(p Progress, fn func() error) error {
 	s.headerLocked = false
 	s.detailLines = 0
 	s.warnCount = 0
+	s.errorDetailEmitted = false
 	_, s.warnPrefix = phasePrefixes(p.Phase)
 	s.runningLabel = formatProgressLabel(p, true)
 	s.startSpinnerLocked()
@@ -203,6 +206,9 @@ func (s *Session) RunWhile(p Progress, fn func() error) error {
 	s.spinnerDone.Wait()
 
 	s.mu.Lock()
+	if fnErr != nil {
+		s.captureStageErrorLocked(fnErr)
+	}
 	s.finishStageLocked(doneLabel, failed)
 	s.stageActive = false
 	s.mu.Unlock()
@@ -331,15 +337,44 @@ type StageDetailKind int
 const (
 	// StageWarn is a recoverable issue; the stage may still succeed.
 	StageWarn StageDetailKind = iota
+	// StageError is a failure tied to the active stage.
+	StageError
 )
 
 func formatStageDetailLine(kind StageDetailKind, prefix, msg string) string {
 	switch kind {
+	case StageError:
+		return ErrorPrefixStyle.Render(prefix+"error: ") + ErrorStyle.Render(msg)
 	case StageWarn:
 		return formatWarningLine(prefix, msg)
 	default:
 		return formatWarningLine(prefix, msg)
 	}
+}
+
+func shortUserMessage(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := err.Error()
+	if idx := strings.IndexByte(msg, '\n'); idx >= 0 {
+		first := strings.TrimSpace(msg[:idx])
+		if first != "" {
+			return first + " (truncated)"
+		}
+	}
+	return msg
+}
+
+func (s *Session) captureStageErrorLocked(err error) {
+	if err == nil || s.errorDetailEmitted {
+		return
+	}
+	s.lockHeaderLocked()
+	fmt.Fprintln(s.w, formatStageDetailLine(StageError, s.warnPrefix, shortUserMessage(err)))
+	s.detailLines++
+	s.errorDetailEmitted = true
+	s.errorDisplayed = true
 }
 
 func (s *Session) stageDetail(kind StageDetailKind, msg string) {
@@ -370,6 +405,25 @@ func (s *Session) stageDetail(kind StageDetailKind, msg string) {
 	if kind == StageWarn {
 		s.warnCount++
 	}
+	if kind == StageError {
+		s.errorDetailEmitted = true
+		s.errorDisplayed = true
+	}
+}
+
+// Error writes a styled error on its own line below the active stage header.
+func (s *Session) Error(msg string) {
+	s.stageDetail(StageError, msg)
+}
+
+// ErrorDisplayed reports whether an error was rendered under a stage header.
+func (s *Session) ErrorDisplayed() bool {
+	if s == nil {
+		return false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.errorDisplayed
 }
 
 // Warn writes a styled warning on its own line below the active stage header.

--- a/internal/termui/progress.go
+++ b/internal/termui/progress.go
@@ -295,6 +295,9 @@ func (s *Session) finishStageLocked(doneLabel string, failed bool) {
 		mark = FailStyle.Render("✗")
 	}
 	line := mark + " " + doneLabel
+	if !failed && s.warnCount > 0 {
+		line += warnCountSuffix(s.warnCount)
+	}
 
 	if s.detailLines > 0 {
 		s.seekStageHeaderLocked()
@@ -304,6 +307,14 @@ func (s *Session) finishStageLocked(doneLabel string, failed bool) {
 	}
 
 	s.overwriteLineLocked(line, true)
+}
+
+func warnCountSuffix(count int) string {
+	noun := "warnings"
+	if count == 1 {
+		noun = "warning"
+	}
+	return FaintStyle.Render(fmt.Sprintf(" (%d %s)", count, noun))
 }
 
 func (s *Session) seekStageHeaderLocked() {

--- a/internal/termui/progress.go
+++ b/internal/termui/progress.go
@@ -74,7 +74,8 @@ type Session struct {
 	mu                sync.Mutex
 	stageActive       bool
 	headerLocked      bool
-	warningCount      int
+	detailLines       int
+	warnCount         int
 	runningLabel      string
 	warnPrefix        string
 	lastFrame         string
@@ -184,7 +185,8 @@ func (s *Session) RunWhile(p Progress, fn func() error) error {
 	s.mu.Lock()
 	s.stageActive = true
 	s.headerLocked = false
-	s.warningCount = 0
+	s.detailLines = 0
+	s.warnCount = 0
 	_, s.warnPrefix = phasePrefixes(p.Phase)
 	s.runningLabel = formatProgressLabel(p, true)
 	s.startSpinnerLocked()
@@ -271,7 +273,7 @@ func (s *Session) finishStageLocked(doneLabel string, failed bool) {
 	}
 	line := mark + " " + doneLabel
 
-	if s.warningCount > 0 {
+	if s.detailLines > 0 {
 		s.seekStageHeaderLocked()
 		s.overwriteLineLocked(line, false)
 		s.seekAfterStageBlockLocked()
@@ -282,15 +284,14 @@ func (s *Session) finishStageLocked(doneLabel string, failed bool) {
 }
 
 func (s *Session) seekStageHeaderLocked() {
-	// Header line, then warningCount warning lines below; cursor starts after the block.
-	n := s.warningCount + 1
+	n := s.detailLines + 1
 	if n > 0 {
 		fmt.Fprint(s.w, ansi.CursorUp(n))
 	}
 }
 
 func (s *Session) seekAfterStageBlockLocked() {
-	n := s.warningCount + 1
+	n := s.detailLines + 1
 	if n > 0 {
 		fmt.Fprint(s.w, ansi.CursorDown(n))
 		// Width-padded overwrite leaves the cursor at the terminal edge; reset column
@@ -324,10 +325,30 @@ func formatWarningLine(prefix, msg string) string {
 	return WarningPrefixStyle.Render(prefix+"warning: ") + WarningStyle.Render(msg)
 }
 
-// Warn writes a styled warning on its own line below the active stage header.
-func (s *Session) Warn(msg string) {
+// StageDetailKind identifies a stage-scoped diagnostic line.
+type StageDetailKind int
+
+const (
+	// StageWarn is a recoverable issue; the stage may still succeed.
+	StageWarn StageDetailKind = iota
+)
+
+func formatStageDetailLine(kind StageDetailKind, prefix, msg string) string {
+	switch kind {
+	case StageWarn:
+		return formatWarningLine(prefix, msg)
+	default:
+		return formatWarningLine(prefix, msg)
+	}
+}
+
+func (s *Session) stageDetail(kind StageDetailKind, msg string) {
 	if s == nil || !s.interactive {
-		slog.Warn(msg)
+		if kind == StageWarn {
+			slog.Warn(msg)
+		} else {
+			slog.Error(msg)
+		}
 		return
 	}
 
@@ -335,13 +356,25 @@ func (s *Session) Warn(msg string) {
 	defer s.mu.Unlock()
 
 	if !s.stageActive {
-		slog.Warn(msg)
+		if kind == StageWarn {
+			slog.Warn(msg)
+		} else {
+			slog.Error(msg)
+		}
 		return
 	}
 
 	s.lockHeaderLocked()
-	fmt.Fprintln(s.w, formatWarningLine(s.warnPrefix, msg))
-	s.warningCount++
+	fmt.Fprintln(s.w, formatStageDetailLine(kind, s.warnPrefix, msg))
+	s.detailLines++
+	if kind == StageWarn {
+		s.warnCount++
+	}
+}
+
+// Warn writes a styled warning on its own line below the active stage header.
+func (s *Session) Warn(msg string) {
+	s.stageDetail(StageWarn, msg)
 }
 
 // Success writes a completion message (styled on TTY, slog otherwise).

--- a/internal/termui/progress.go
+++ b/internal/termui/progress.go
@@ -70,6 +70,7 @@ type Session struct {
 	w           io.Writer
 	fd          int
 	interactive bool
+	termWidthOverride int // tests only; when > 0, used instead of terminal size
 
 	mu                sync.Mutex
 	stageActive       bool
@@ -323,6 +324,9 @@ func (s *Session) seekAfterStageBlockLocked() {
 }
 
 func (s *Session) termWidth() int {
+	if s.termWidthOverride > 0 {
+		return s.termWidthOverride
+	}
 	_, width, err := term.GetSize(s.fd)
 	if err != nil || width <= 0 {
 		return defaultTermWidth
@@ -382,13 +386,53 @@ func shortUserMessage(err error) string {
 	return msg
 }
 
+func (s *Session) writeStageDetailLinesLocked(kind StageDetailKind, msg string) {
+	for _, line := range splitDetailMessage(msg) {
+		formatted := truncateDetailLine(kind, s.warnPrefix, line, s.termWidth())
+		fmt.Fprintln(s.w, formatted)
+		s.detailLines++
+		if kind == StageWarn {
+			s.warnCount++
+		}
+	}
+}
+
+func splitDetailMessage(msg string) []string {
+	parts := strings.Split(msg, "\n")
+	var lines []string
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			lines = append(lines, p)
+		}
+	}
+	if len(lines) == 0 {
+		return []string{msg}
+	}
+	return lines
+}
+
+func truncateDetailLine(kind StageDetailKind, prefix, msg string, maxWidth int) string {
+	const ellipsis = "…"
+	runes := []rune(msg)
+	for {
+		candidate := formatStageDetailLine(kind, prefix, string(runes))
+		if lipgloss.Width(candidate) <= maxWidth {
+			return candidate
+		}
+		if len(runes) == 0 {
+			return formatStageDetailLine(kind, prefix, ellipsis)
+		}
+		runes = runes[:len(runes)-1]
+	}
+}
+
 func (s *Session) captureStageErrorLocked(err error) {
 	if err == nil || s.errorDetailEmitted {
 		return
 	}
 	s.lockHeaderLocked()
-	fmt.Fprintln(s.w, formatStageDetailLine(StageError, s.warnPrefix, shortUserMessage(err)))
-	s.detailLines++
+	s.writeStageDetailLinesLocked(StageError, shortUserMessage(err))
 	s.errorDetailEmitted = true
 	s.errorDisplayed = true
 }
@@ -416,11 +460,7 @@ func (s *Session) stageDetail(kind StageDetailKind, msg string) {
 	}
 
 	s.lockHeaderLocked()
-	fmt.Fprintln(s.w, formatStageDetailLine(kind, s.warnPrefix, msg))
-	s.detailLines++
-	if kind == StageWarn {
-		s.warnCount++
-	}
+	s.writeStageDetailLinesLocked(kind, msg)
 	if kind == StageError {
 		s.errorDetailEmitted = true
 		s.errorDisplayed = true
@@ -460,7 +500,12 @@ func (s *Session) Success(msg string) {
 
 // newSessionForTest builds a session with a forced interactive flag (tests only).
 func newSessionForTest(w io.Writer) *Session {
-	return &Session{w: w, interactive: true}
+	return &Session{w: w, interactive: true, termWidthOverride: defaultTermWidth}
+}
+
+// newNarrowSessionForTest builds an interactive session with a narrow terminal width.
+func newNarrowSessionForTest(w io.Writer, width int) *Session {
+	return &Session{w: w, interactive: true, termWidthOverride: width}
 }
 
 var spinnerFrameStyle = lipgloss.NewStyle().Foreground(lipgloss.Color(AccentColor))

--- a/internal/termui/progress_test.go
+++ b/internal/termui/progress_test.go
@@ -374,6 +374,25 @@ func detailBelowStageHeader(out, stage, prefix string) bool {
 	return strings.Contains(out[stageIdx:stageIdx+detailIdx], "\n")
 }
 
+func TestSession_RunWhile_warnedSuccessShowsCountSuffix(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	s := newSessionForTest(&buf)
+	err := s.RunWhile(Progress{Phase: PhaseCollectProfiles, Detail: "cpu, memory"}, func() error {
+		s.Warn("first")
+		s.Warn("second")
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("RunWhile() err = %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "2 warnings") {
+		t.Fatalf("expected warning count suffix: %q", out)
+	}
+}
+
 func TestSession_Warn_truncatesOnNarrowTerminal(t *testing.T) {
 	t.Parallel()
 

--- a/internal/termui/progress_test.go
+++ b/internal/termui/progress_test.go
@@ -374,6 +374,28 @@ func detailBelowStageHeader(out, stage, prefix string) bool {
 	return strings.Contains(out[stageIdx:stageIdx+detailIdx], "\n")
 }
 
+func TestSession_Warn_truncatesOnNarrowTerminal(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	s := newNarrowSessionForTest(&buf, 36)
+	longMsg := strings.Repeat("x", 80)
+	err := s.RunWhile(Progress{Phase: PhasePrepare}, func() error {
+		s.Warn(longMsg)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("RunWhile() err = %v", err)
+	}
+	out := buf.String()
+	if strings.Count(out, longMsg) > 0 {
+		t.Fatalf("expected truncated message, got full repeat in %q", out)
+	}
+	if !strings.Contains(out, "✓") {
+		t.Fatalf("expected success marker after truncate: %q", out)
+	}
+}
+
 func TestSession_WarningsStayBelowHeaderWithMultipleWarns(t *testing.T) {
 	t.Parallel()
 

--- a/internal/termui/progress_test.go
+++ b/internal/termui/progress_test.go
@@ -332,6 +332,19 @@ func TestSession_RunWhile_stage2Warnings(t *testing.T) {
 	}
 }
 
+func TestErrorWasStaged(t *testing.T) {
+	t.Parallel()
+
+	base := errors.New("boom")
+	if ErrorWasStaged(base) {
+		t.Fatal("expected false for plain error")
+	}
+	wrapped := StagedDisplay(base)
+	if !ErrorWasStaged(wrapped) {
+		t.Fatal("expected true for staged error")
+	}
+}
+
 func TestSession_ErrorDisplayed(t *testing.T) {
 	t.Parallel()
 

--- a/internal/termui/progress_test.go
+++ b/internal/termui/progress_test.go
@@ -159,6 +159,33 @@ func TestSession_PreparingThenBenchmark(t *testing.T) {
 	}
 }
 
+func TestSession_BeginCollect_printsSectionBreak(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	s := newSessionForTest(&buf)
+	s.BeginCollect()
+	err := s.RunWhile(Progress{Phase: PhasePrepare}, func() error { return nil })
+	if err != nil {
+		t.Fatalf("RunWhile() err = %v", err)
+	}
+	out := buf.String()
+	if !strings.HasPrefix(out, "\n") {
+		t.Fatalf("expected leading blank line, got %q", out)
+	}
+	if !strings.Contains(out, CollectSectionTitle) {
+		t.Fatalf("missing section title: %q", out)
+	}
+	if !strings.Contains(out, "─") {
+		t.Fatalf("missing section rule: %q", out)
+	}
+	titleIdx := strings.Index(out, CollectSectionTitle)
+	prepIdx := strings.Index(out, "Preparing")
+	if titleIdx < 0 || prepIdx < 0 || prepIdx <= titleIdx {
+		t.Fatalf("Preparing should follow section title: %q", out)
+	}
+}
+
 func TestSession_BeginBenchmark_leadingSeparator(t *testing.T) {
 	t.Parallel()
 

--- a/internal/termui/progress_test.go
+++ b/internal/termui/progress_test.go
@@ -292,7 +292,6 @@ func TestSession_RunWhile_stageErrorsPerPhase(t *testing.T) {
 		{PhaseCollectFunctionProfiles, "2) Collect per-function text profiles"},
 	}
 	for _, tc := range cases {
-		tc := tc
 		t.Run(string(tc.phase), func(t *testing.T) {
 			t.Parallel()
 			var buf bytes.Buffer

--- a/internal/termui/progress_test.go
+++ b/internal/termui/progress_test.go
@@ -232,6 +232,135 @@ func warningBelowStageHeader(out, stage string) bool {
 	return strings.Contains(out[stageIdx:stageIdx+warnIdx], "\n")
 }
 
+func TestSession_RunWhile_failedStageShowsErrorDetail(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	s := newSessionForTest(&buf)
+	runErr := errors.New("setup failed")
+	err := s.RunWhile(Progress{Phase: PhasePrepare}, func() error {
+		return runErr
+	})
+	if !errors.Is(err, runErr) {
+		t.Fatalf("RunWhile() err = %v, want %v", err, runErr)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "✗") {
+		t.Fatalf("output missing failure marker: %q", out)
+	}
+	if !strings.Contains(out, "error:") {
+		t.Fatalf("output missing error detail: %q", out)
+	}
+	if !strings.Contains(out, "setup failed") {
+		t.Fatalf("output missing error message: %q", out)
+	}
+	if !detailBelowStageHeader(out, "Preparing", "error:") {
+		t.Fatalf("error should be below Preparing header: %q", out)
+	}
+}
+
+func TestSession_RunWhile_failedAfterWarnings(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	s := newSessionForTest(&buf)
+	err := s.RunWhile(Progress{Phase: PhaseCollectProfiles, Detail: "cpu"}, func() error {
+		s.Warn("png skipped")
+		return errors.New("profile text failed")
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	out := buf.String()
+	if !strings.Contains(out, "warning:") || !strings.Contains(out, "error:") {
+		t.Fatalf("expected warning and error lines: %q", out)
+	}
+	if !strings.Contains(out, "✗") {
+		t.Fatalf("expected failure marker: %q", out)
+	}
+}
+
+func TestSession_RunWhile_stageErrorsPerPhase(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		phase Phase
+		label string
+	}{
+		{PhaseRunBenchmark, "0) Run benchmark"},
+		{PhaseCollectProfiles, "1) Collect profiles"},
+		{PhaseCollectFunctionProfiles, "2) Collect per-function text profiles"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(string(tc.phase), func(t *testing.T) {
+			t.Parallel()
+			var buf bytes.Buffer
+			s := newSessionForTest(&buf)
+			err := s.RunWhile(Progress{Phase: tc.phase}, func() error {
+				return errors.New("phase failed")
+			})
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			out := buf.String()
+			if !strings.Contains(out, tc.label) {
+				t.Fatalf("missing label %q in %q", tc.label, out)
+			}
+			if !detailBelowStageHeader(out, tc.label, "error:") {
+				t.Fatalf("error not below header for %s: %q", tc.phase, out)
+			}
+		})
+	}
+}
+
+func TestSession_RunWhile_stage2Warnings(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	s := newSessionForTest(&buf)
+	err := s.RunWhile(Progress{Phase: PhaseCollectFunctionProfiles}, func() error {
+		s.Warn("skipping Foo")
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("RunWhile() err = %v", err)
+	}
+	out := buf.String()
+	if !detailBelowStageHeader(out, "2) Collect per-function text profiles", "warning:") {
+		t.Fatalf("stage 2 warning not below header: %q", out)
+	}
+}
+
+func TestSession_ErrorDisplayed(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	s := newSessionForTest(&buf)
+	if s.ErrorDisplayed() {
+		t.Fatal("expected false before run")
+	}
+	_ = s.RunWhile(Progress{Phase: PhasePrepare}, func() error {
+		return errors.New("boom")
+	})
+	if !s.ErrorDisplayed() {
+		t.Fatal("expected true after staged error")
+	}
+	_ = buf.String()
+}
+
+func detailBelowStageHeader(out, stage, prefix string) bool {
+	stageIdx := strings.Index(out, stage)
+	if stageIdx < 0 {
+		return false
+	}
+	detailIdx := strings.Index(out[stageIdx:], prefix)
+	if detailIdx < 0 {
+		return false
+	}
+	return strings.Contains(out[stageIdx:stageIdx+detailIdx], "\n")
+}
+
 func TestSession_WarningsStayBelowHeaderWithMultipleWarns(t *testing.T) {
 	t.Parallel()
 

--- a/internal/termui/styles.go
+++ b/internal/termui/styles.go
@@ -14,6 +14,10 @@ var (
 	WarningStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("214"))
 	// WarningPrefixStyle styles the fixed warning prefix (indented, faint).
 	WarningPrefixStyle = lipgloss.NewStyle().Faint(true).Foreground(lipgloss.Color("214"))
+	// ErrorStyle styles the error message body on interactive terminals.
+	ErrorStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("196"))
+	// ErrorPrefixStyle styles the fixed error prefix (indented, faint).
+	ErrorPrefixStyle = lipgloss.NewStyle().Faint(true).Foreground(lipgloss.Color("196"))
 	// SuccessStyle styles the final success line on interactive terminals.
 	SuccessStyle = lipgloss.NewStyle().Faint(true).Foreground(lipgloss.Color("42"))
 	// DoneStyle styles the completion marker on finished stages.

--- a/internal/termui/styles.go
+++ b/internal/termui/styles.go
@@ -22,4 +22,9 @@ var (
 	FailStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("196"))
 	// BenchmarkTitleStyle styles the benchmark group header in the progress log.
 	BenchmarkTitleStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color(AccentColor))
+	// SectionRuleStyle styles the faint rule under the collect section title.
+	SectionRuleStyle = lipgloss.NewStyle().Faint(true)
 )
+
+// CollectSectionTitle is the heading printed before the prepare stage.
+const CollectSectionTitle = "Collecting profiles"


### PR DESCRIPTION
## Summary
- Add a visual break between Survey prompts and collect pipeline (Collecting profiles title + rule) via BeginCollect.
- Unify stage-scoped diagnostics: warnings and errors render indented under the stage where they occurred; RunWhile auto-captures returned errors for Prepare and all benchmark stages.
- Suppress duplicate stderr from prof ui when the error is already shown in the progress tree.
- Truncate detail lines on narrow terminals, cap stage-2 per-function warning spam, and show (N warnings) on successful warned stages.

## Test plan
- [x] go test ./... -short
- [ ] prof ui: confirm blank line + Collecting profiles section before Preparing
- [ ] prof ui with Graphviz missing: PNG warnings under stage 1 with (N warnings) suffix
- [ ] Induce benchmark failure: error under stage 0, no duplicate stderr line


Made with [Cursor](https://cursor.com)