### PR TITLE
Polish prof ui configure survey and collect handoff

### DIFF
--- a/cli/collect_preview.go
+++ b/cli/collect_preview.go
@@ -10,10 +10,10 @@ import (
 	"github.com/AlexsanderHamir/prof/internal/termui"
 )
 
-const missingConfigFilterWarning = "No prof.json found; proceeding without function filters (run prof config init to add one)."
+const missingConfigFilterWarning = config.MissingConfigUserWarning
 
 // printCollectionFilterPreview reports filter settings after benchmark selection.
-// It returns true when a warning was printed (TTY only); gaps are added around warnings.
+// It returns true when the missing-config warning was printed (TTY only).
 func printCollectionFilterPreview(w io.Writer, interactive bool, svc *app.Services, benchNames []string) bool {
 	cfg, err := svc.Config.Load()
 	if err != nil {

--- a/cli/collect_preview.go
+++ b/cli/collect_preview.go
@@ -2,25 +2,42 @@ package cli
 
 import (
 	"fmt"
-	"os"
+	"io"
 	"strings"
 
 	"github.com/AlexsanderHamir/prof/internal/app"
 	"github.com/AlexsanderHamir/prof/internal/config"
+	"github.com/AlexsanderHamir/prof/internal/termui"
 )
 
-func printCollectionFilterPreview(svc *app.Services, benchNames []string) {
+const missingConfigFilterWarning = "No prof.json found; proceeding without function filters (run prof config init to add one)."
+
+// printCollectionFilterPreview reports filter settings after benchmark selection.
+// It returns true when a warning was printed (TTY only); gaps are added around warnings.
+func printCollectionFilterPreview(w io.Writer, interactive bool, svc *app.Services, benchNames []string) bool {
 	cfg, err := svc.Config.Load()
 	if err != nil {
-		fmt.Fprintln(os.Stdout, "Collection filters: none (no prof.json or load failed)")
-		return
+		if interactive {
+			termui.StepGap(w)
+			termui.PrintWarning(w, termui.ConfigureDetailPrefix, missingConfigFilterWarning)
+			termui.StepGap(w)
+			return true
+		}
+		fmt.Fprintln(w, "Collection filters: none (no prof.json or load failed)")
+		return false
 	}
-	fmt.Fprintln(os.Stdout, "Collection filters from prof.json:")
+
+	if interactive {
+		return false
+	}
+
+	fmt.Fprintln(w, "Collection filters from prof.json:")
 	for _, bench := range benchNames {
 		filter := config.ResolveCollectionFilter(cfg, config.CollectionTargetAuto(bench))
-		fmt.Fprintf(os.Stdout, "  %s — include: %s; ignore: %s\n",
+		fmt.Fprintf(w, "  %s — include: %s; ignore: %s\n",
 			bench, formatFilterList(filter.IncludePrefixes), formatFilterList(filter.IgnoreFunctions))
 	}
+	return false
 }
 
 func formatFilterList(items []string) string {

--- a/cli/collect_preview.go
+++ b/cli/collect_preview.go
@@ -18,8 +18,7 @@ func printCollectionFilterPreview(w io.Writer, interactive bool, svc *app.Servic
 	cfg, err := svc.Config.Load()
 	if err != nil {
 		if interactive {
-			termui.StepGap(w)
-			termui.PrintWarning(w, termui.ConfigureDetailPrefix, missingConfigFilterWarning)
+			termui.PrintWarning(w, termui.ConfigureWarningPrefix, missingConfigFilterWarning)
 			termui.StepGap(w)
 			return true
 		}

--- a/cli/collect_preview_test.go
+++ b/cli/collect_preview_test.go
@@ -1,6 +1,23 @@
 package cli
 
-import "testing"
+import (
+	"strings"
+	"testing"
+
+	"github.com/AlexsanderHamir/prof/internal/termui"
+)
+
+func TestFormatWarningLine_matchesPipelineStyle(t *testing.T) {
+	t.Parallel()
+
+	got := termui.FormatWarningLine(termui.ConfigureDetailPrefix, "test warn")
+	if !strings.Contains(got, "warning:") {
+		t.Fatalf("missing warning prefix: %q", got)
+	}
+	if !strings.Contains(got, "test warn") {
+		t.Fatalf("missing message: %q", got)
+	}
+}
 
 func TestFormatFilterList(t *testing.T) {
 	t.Parallel()

--- a/cli/collect_preview_test.go
+++ b/cli/collect_preview_test.go
@@ -10,7 +10,7 @@ import (
 func TestFormatWarningLine_matchesPipelineStyle(t *testing.T) {
 	t.Parallel()
 
-	got := termui.FormatWarningLine(termui.ConfigureDetailPrefix, "test warn")
+	got := termui.FormatWarningLine(termui.ConfigureWarningPrefix, "test warn")
 	if !strings.Contains(got, "warning:") {
 		t.Fatalf("missing warning prefix: %q", got)
 	}

--- a/cli/survey_input.go
+++ b/cli/survey_input.go
@@ -1,17 +1,24 @@
 package cli
 
-import "github.com/AlecAivazis/survey/v2"
+import (
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/AlecAivazis/survey/v2/terminal"
+)
 
-// cleanInput wraps survey.Input and skips Cleanup.
+// cleanInput wraps survey.Input and replaces Cleanup.
 //
-// survey.AskOne always calls Cleanup after Input.Prompt, which re-renders
-// "? question: answer" on a new line. When the terminal echoes typed input
-// (ShowCursor) or readline emits an extra newline (Windows), that cleanup line
-// duplicates the answer the user already sees — it is not a second prompt.
+// survey.AskOne normally calls Cleanup to re-print "? question: answer", which
+// duplicates the line the user already typed. We skip that re-print and only
+// erase the blank line readline leaves after Enter so the next prompt can follow
+// immediately when there is no warning between steps.
 type cleanInput struct {
 	survey.Input
 }
 
-func (cleanInput) Cleanup(*survey.PromptConfig, interface{}) error {
-	return nil
+func (c *cleanInput) Cleanup(_ *survey.PromptConfig, _ interface{}) error {
+	stdio := c.Stdio()
+	if stdio.Out == nil {
+		return nil
+	}
+	return terminal.EraseLine(stdio.Out, terminal.ERASE_LINE_ALL)
 }

--- a/cli/survey_input.go
+++ b/cli/survey_input.go
@@ -1,0 +1,17 @@
+package cli
+
+import "github.com/AlecAivazis/survey/v2"
+
+// cleanInput wraps survey.Input and skips Cleanup.
+//
+// survey.AskOne always calls Cleanup after Input.Prompt, which re-renders
+// "? question: answer" on a new line. When the terminal echoes typed input
+// (ShowCursor) or readline emits an extra newline (Windows), that cleanup line
+// duplicates the answer the user already sees — it is not a second prompt.
+type cleanInput struct {
+	survey.Input
+}
+
+func (cleanInput) Cleanup(*survey.PromptConfig, interface{}) error {
+	return nil
+}

--- a/cli/survey_input.go
+++ b/cli/survey_input.go
@@ -1,24 +1,49 @@
 package cli
 
 import (
-	"github.com/AlecAivazis/survey/v2"
-	"github.com/AlecAivazis/survey/v2/terminal"
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
 )
 
-// cleanInput wraps survey.Input and replaces Cleanup.
-//
-// survey.AskOne normally calls Cleanup to re-print "? question: answer", which
-// duplicates the line the user already typed. We skip that re-print and only
-// erase the blank line readline leaves after Enter so the next prompt can follow
-// immediately when there is no warning between steps.
-type cleanInput struct {
-	survey.Input
+// Survey question styling matches github.com/AlecAivazis/survey/v2 defaults (green+hb ?, bold message).
+var (
+	configureQuestionIcon    = lipgloss.NewStyle().Foreground(lipgloss.Color("2")).Bold(true)
+	configureQuestionMessage = lipgloss.NewStyle().Bold(true)
+	configureQuestionDefault = lipgloss.NewStyle().Foreground(lipgloss.Color("15"))
+)
+
+func formatConfigurePrompt(message, defaultVal string) string {
+	icon := configureQuestionIcon.Render("?")
+	msg := configureQuestionMessage.Render(message)
+	if defaultVal != "" {
+		def := configureQuestionDefault.Render("(" + defaultVal + ")")
+		return icon + " " + msg + " " + def + " "
+	}
+	return icon + " " + msg + " "
 }
 
-func (c *cleanInput) Cleanup(_ *survey.PromptConfig, _ interface{}) error {
-	stdio := c.Stdio()
-	if stdio.Out == nil {
-		return nil
+// askConfigureLine prints a survey-style "? message" prompt and reads one line.
+// It does not add extra blank lines between consecutive prompts.
+func askConfigureLine(r *bufio.Reader, w io.Writer, message, defaultVal string) (string, error) {
+	if r == nil {
+		return "", errors.New("reader is nil")
 	}
-	return terminal.EraseLine(stdio.Out, terminal.ERASE_LINE_ALL)
+	fmt.Fprint(w, formatConfigurePrompt(message, defaultVal))
+	line, err := r.ReadString('\n')
+	if err != nil {
+		return "", err
+	}
+	line = strings.TrimSpace(line)
+	if line == "" && defaultVal != "" {
+		return defaultVal, nil
+	}
+	if line == "" {
+		return "", errors.New("required")
+	}
+	return line, nil
 }

--- a/cli/survey_input_test.go
+++ b/cli/survey_input_test.go
@@ -1,22 +1,37 @@
 package cli
 
 import (
+	"bufio"
+	"bytes"
+	"io"
+	"strings"
 	"testing"
-
-	"github.com/AlecAivazis/survey/v2"
 )
 
-func TestCleanInput_CleanupErasesTrailingLine(t *testing.T) {
+func TestAskConfigureLine_usesDefault(t *testing.T) {
 	t.Parallel()
 
-	var p survey.Prompt = &cleanInput{Input: survey.Input{Message: "test"}}
-	c, ok := p.(interface {
-		Cleanup(*survey.PromptConfig, interface{}) error
-	})
-	if !ok {
-		t.Fatal("cleanInput should implement Cleanup")
+	var out bytes.Buffer
+	got, err := askConfigureLine(bufio.NewReader(strings.NewReader("\n")), &out, "Number of runs (count):", "1")
+	if err != nil {
+		t.Fatalf("askConfigureLine() err = %v", err)
 	}
-	if err := c.Cleanup(&survey.PromptConfig{}, "answer"); err != nil {
-		t.Fatalf("Cleanup() = %v", err)
+	if got != "1" {
+		t.Fatalf("got %q, want 1", got)
+	}
+	if !strings.Contains(out.String(), "Number of runs (count):") {
+		t.Fatalf("output = %q", out.String())
+	}
+	if !strings.Contains(out.String(), configureQuestionIcon.Render("?")) {
+		t.Fatalf("missing styled question icon: %q", out.String())
+	}
+}
+
+func TestAskConfigureLine_required(t *testing.T) {
+	t.Parallel()
+
+	_, err := askConfigureLine(bufio.NewReader(strings.NewReader("\n")), io.Discard, "Tag name:", "")
+	if err == nil {
+		t.Fatal("expected required error")
 	}
 }

--- a/cli/survey_input_test.go
+++ b/cli/survey_input_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 )
 
-func TestCleanInput_CleanupIsNoop(t *testing.T) {
+func TestCleanInput_CleanupErasesTrailingLine(t *testing.T) {
 	t.Parallel()
 
 	var p survey.Prompt = &cleanInput{Input: survey.Input{Message: "test"}}

--- a/cli/survey_input_test.go
+++ b/cli/survey_input_test.go
@@ -1,0 +1,22 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/AlecAivazis/survey/v2"
+)
+
+func TestCleanInput_CleanupIsNoop(t *testing.T) {
+	t.Parallel()
+
+	var p survey.Prompt = &cleanInput{Input: survey.Input{Message: "test"}}
+	c, ok := p.(interface {
+		Cleanup(*survey.PromptConfig, interface{}) error
+	})
+	if !ok {
+		t.Fatal("cleanInput should implement Cleanup")
+	}
+	if err := c.Cleanup(&survey.PromptConfig{}, "answer"); err != nil {
+		t.Fatalf("Cleanup() = %v", err)
+	}
+}

--- a/cli/tui.go
+++ b/cli/tui.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
 	"os"
@@ -15,7 +16,6 @@ import (
 )
 
 func runTUI(svc *app.Services, _ *cobra.Command, _ []string) error {
-	// Get current working directory for scope-aware benchmark discovery
 	currentDir, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("failed to get current working directory: %w", err)
@@ -30,10 +30,10 @@ func runTUI(svc *app.Services, _ *cobra.Command, _ []string) error {
 		return errors.New("no benchmarks found in this directory or its subdirectories (look for func BenchmarkXxx(b *testing.B) in *_test.go)")
 	}
 
-	if term.IsTerminal(int(os.Stdout.Fd())) {
+	surveyTTY := term.IsTerminal(int(os.Stdout.Fd()))
+	if surveyTTY {
 		termui.PrintSection(os.Stdout, int(os.Stdout.Fd()), termui.SurveySectionTitle)
 	}
-	surveyTTY := term.IsTerminal(int(os.Stdout.Fd()))
 
 	var selectedBenches []string
 	benchPrompt := &survey.MultiSelect{
@@ -54,16 +54,13 @@ func runTUI(svc *app.Services, _ *cobra.Command, _ []string) error {
 		Options: profilesOptions,
 		Default: []string{"cpu"},
 	}
-
 	if err = survey.AskOne(profilesPrompt, &selectedProfiles, survey.WithValidator(survey.Required)); err != nil {
 		return err
 	}
 
-	var countStr string
-	if err = survey.AskOne(&cleanInput{Input: survey.Input{
-		Message: "Number of runs (count):",
-		Default: "1",
-	}}, &countStr, survey.WithValidator(survey.Required)); err != nil {
+	reader := bufio.NewReader(os.Stdin)
+	countStr, err := askConfigureLine(reader, os.Stdout, "Number of runs (count):", "1")
+	if err != nil {
 		return err
 	}
 	runCount, convErr := strconv.Atoi(countStr)
@@ -71,15 +68,9 @@ func runTUI(svc *app.Services, _ *cobra.Command, _ []string) error {
 		return fmt.Errorf("invalid count: %s", countStr)
 	}
 
-	var tagStr string
-	if err = survey.AskOne(&cleanInput{Input: survey.Input{
-		Message: "Tag name (used to group results under bench/<tag>):",
-	}}, &tagStr, survey.WithValidator(survey.Required)); err != nil {
+	tagStr, err := askConfigureLine(reader, os.Stdout, "Tag name (used to group results under bench/<tag>):", "")
+	if err != nil {
 		return err
-	}
-
-	if surveyTTY {
-		termui.EndSection(os.Stdout)
 	}
 
 	collect := &intent.CollectIntent{

--- a/cli/tui.go
+++ b/cli/tui.go
@@ -45,7 +45,7 @@ func runTUI(svc *app.Services, _ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	printCollectionFilterPreview(os.Stdout, surveyTTY, svc, selectedBenches)
+	missingConfigWarnShown := printCollectionFilterPreview(os.Stdout, surveyTTY, svc, selectedBenches)
 
 	profilesOptions := svc.Collect.SupportedProfiles()
 	var selectedProfiles []string
@@ -74,10 +74,11 @@ func runTUI(svc *app.Services, _ *cobra.Command, _ []string) error {
 	}
 
 	collect := &intent.CollectIntent{
-		Benchmarks: selectedBenches,
-		Profiles:   selectedProfiles,
-		Tag:        tagStr,
-		Count:      runCount,
+		Benchmarks:             selectedBenches,
+		Profiles:               selectedProfiles,
+		Tag:                    tagStr,
+		Count:                  runCount,
+		MissingConfigWarnShown: missingConfigWarnShown,
 	}
 	collect.Normalize()
 	return intent.RunValidated(collect, svc)

--- a/cli/tui.go
+++ b/cli/tui.go
@@ -9,7 +9,9 @@ import (
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/AlexsanderHamir/prof/internal/app"
 	"github.com/AlexsanderHamir/prof/internal/intent"
+	"github.com/AlexsanderHamir/prof/internal/termui"
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 func runTUI(svc *app.Services, _ *cobra.Command, _ []string) error {
@@ -26,6 +28,10 @@ func runTUI(svc *app.Services, _ *cobra.Command, _ []string) error {
 
 	if len(benchNames) == 0 {
 		return errors.New("no benchmarks found in this directory or its subdirectories (look for func BenchmarkXxx(b *testing.B) in *_test.go)")
+	}
+
+	if term.IsTerminal(int(os.Stdout.Fd())) {
+		termui.PrintSection(os.Stdout, int(os.Stdout.Fd()), termui.SurveySectionTitle)
 	}
 
 	var selectedBenches []string
@@ -69,6 +75,10 @@ func runTUI(svc *app.Services, _ *cobra.Command, _ []string) error {
 		Message: "Tag name (used to group results under bench/<tag>):",
 	}}, &tagStr, survey.WithValidator(survey.Required)); err != nil {
 		return err
+	}
+
+	if term.IsTerminal(int(os.Stdout.Fd())) {
+		termui.EndSection(os.Stdout)
 	}
 
 	collect := &intent.CollectIntent{

--- a/cli/tui.go
+++ b/cli/tui.go
@@ -12,11 +12,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// surveyInputOpts shows the terminal cursor on free-text Survey prompts (hidden by default).
-var surveyInputOpts = []survey.AskOpt{
-	survey.WithShowCursor(true),
-}
-
 func runTUI(svc *app.Services, _ *cobra.Command, _ []string) error {
 	// Get current working directory for scope-aware benchmark discovery
 	currentDir, err := os.Getwd()
@@ -59,7 +54,7 @@ func runTUI(svc *app.Services, _ *cobra.Command, _ []string) error {
 
 	var countStr string
 	countPrompt := &survey.Input{Message: "Number of runs (count):", Default: "1"}
-	if err = survey.AskOne(countPrompt, &countStr, append(surveyInputOpts, survey.WithValidator(survey.Required))...); err != nil {
+	if err = survey.AskOne(countPrompt, &countStr, survey.WithValidator(survey.Required)); err != nil {
 		return err
 	}
 	runCount, convErr := strconv.Atoi(countStr)
@@ -69,7 +64,7 @@ func runTUI(svc *app.Services, _ *cobra.Command, _ []string) error {
 
 	var tagStr string
 	tagPrompt := &survey.Input{Message: "Tag name (used to group results under bench/<tag>):"}
-	if err = survey.AskOne(tagPrompt, &tagStr, append(surveyInputOpts, survey.WithValidator(survey.Required))...); err != nil {
+	if err = survey.AskOne(tagPrompt, &tagStr, survey.WithValidator(survey.Required)); err != nil {
 		return err
 	}
 

--- a/cli/tui.go
+++ b/cli/tui.go
@@ -33,6 +33,11 @@ func runTUI(svc *app.Services, _ *cobra.Command, _ []string) error {
 	if term.IsTerminal(int(os.Stdout.Fd())) {
 		termui.PrintSection(os.Stdout, int(os.Stdout.Fd()), termui.SurveySectionTitle)
 	}
+	surveyGap := func() {
+		if term.IsTerminal(int(os.Stdout.Fd())) {
+			termui.StepGap(os.Stdout)
+		}
+	}
 
 	var selectedBenches []string
 	benchPrompt := &survey.MultiSelect{
@@ -43,8 +48,10 @@ func runTUI(svc *app.Services, _ *cobra.Command, _ []string) error {
 	if err = survey.AskOne(benchPrompt, &selectedBenches, survey.WithValidator(survey.Required)); err != nil {
 		return err
 	}
+	surveyGap()
 
 	printCollectionFilterPreview(svc, selectedBenches)
+	surveyGap()
 
 	profilesOptions := svc.Collect.SupportedProfiles()
 	var selectedProfiles []string
@@ -57,6 +64,7 @@ func runTUI(svc *app.Services, _ *cobra.Command, _ []string) error {
 	if err = survey.AskOne(profilesPrompt, &selectedProfiles, survey.WithValidator(survey.Required)); err != nil {
 		return err
 	}
+	surveyGap()
 
 	var countStr string
 	if err = survey.AskOne(&cleanInput{Input: survey.Input{
@@ -69,6 +77,7 @@ func runTUI(svc *app.Services, _ *cobra.Command, _ []string) error {
 	if convErr != nil || runCount < 1 {
 		return fmt.Errorf("invalid count: %s", countStr)
 	}
+	surveyGap()
 
 	var tagStr string
 	if err = survey.AskOne(&cleanInput{Input: survey.Input{

--- a/cli/tui.go
+++ b/cli/tui.go
@@ -53,8 +53,10 @@ func runTUI(svc *app.Services, _ *cobra.Command, _ []string) error {
 	}
 
 	var countStr string
-	countPrompt := &survey.Input{Message: "Number of runs (count):", Default: "1"}
-	if err = survey.AskOne(countPrompt, &countStr, survey.WithValidator(survey.Required)); err != nil {
+	if err = survey.AskOne(&cleanInput{Input: survey.Input{
+		Message: "Number of runs (count):",
+		Default: "1",
+	}}, &countStr, survey.WithValidator(survey.Required)); err != nil {
 		return err
 	}
 	runCount, convErr := strconv.Atoi(countStr)
@@ -63,8 +65,9 @@ func runTUI(svc *app.Services, _ *cobra.Command, _ []string) error {
 	}
 
 	var tagStr string
-	tagPrompt := &survey.Input{Message: "Tag name (used to group results under bench/<tag>):"}
-	if err = survey.AskOne(tagPrompt, &tagStr, survey.WithValidator(survey.Required)); err != nil {
+	if err = survey.AskOne(&cleanInput{Input: survey.Input{
+		Message: "Tag name (used to group results under bench/<tag>):",
+	}}, &tagStr, survey.WithValidator(survey.Required)); err != nil {
 		return err
 	}
 

--- a/cli/tui.go
+++ b/cli/tui.go
@@ -33,11 +33,7 @@ func runTUI(svc *app.Services, _ *cobra.Command, _ []string) error {
 	if term.IsTerminal(int(os.Stdout.Fd())) {
 		termui.PrintSection(os.Stdout, int(os.Stdout.Fd()), termui.SurveySectionTitle)
 	}
-	surveyGap := func() {
-		if term.IsTerminal(int(os.Stdout.Fd())) {
-			termui.StepGap(os.Stdout)
-		}
-	}
+	surveyTTY := term.IsTerminal(int(os.Stdout.Fd()))
 
 	var selectedBenches []string
 	benchPrompt := &survey.MultiSelect{
@@ -48,10 +44,8 @@ func runTUI(svc *app.Services, _ *cobra.Command, _ []string) error {
 	if err = survey.AskOne(benchPrompt, &selectedBenches, survey.WithValidator(survey.Required)); err != nil {
 		return err
 	}
-	surveyGap()
 
-	printCollectionFilterPreview(svc, selectedBenches)
-	surveyGap()
+	printCollectionFilterPreview(os.Stdout, surveyTTY, svc, selectedBenches)
 
 	profilesOptions := svc.Collect.SupportedProfiles()
 	var selectedProfiles []string
@@ -64,7 +58,6 @@ func runTUI(svc *app.Services, _ *cobra.Command, _ []string) error {
 	if err = survey.AskOne(profilesPrompt, &selectedProfiles, survey.WithValidator(survey.Required)); err != nil {
 		return err
 	}
-	surveyGap()
 
 	var countStr string
 	if err = survey.AskOne(&cleanInput{Input: survey.Input{
@@ -77,7 +70,6 @@ func runTUI(svc *app.Services, _ *cobra.Command, _ []string) error {
 	if convErr != nil || runCount < 1 {
 		return fmt.Errorf("invalid count: %s", countStr)
 	}
-	surveyGap()
 
 	var tagStr string
 	if err = survey.AskOne(&cleanInput{Input: survey.Input{
@@ -86,7 +78,7 @@ func runTUI(svc *app.Services, _ *cobra.Command, _ []string) error {
 		return err
 	}
 
-	if term.IsTerminal(int(os.Stdout.Fd())) {
+	if surveyTTY {
 		termui.EndSection(os.Stdout)
 	}
 

--- a/engine/collect/entry.go
+++ b/engine/collect/entry.go
@@ -46,8 +46,8 @@ func RunAuto(runner tooling.Runner, opts AutoOptions) error {
 	if session.Interactive() {
 		session.BeginCollect()
 		if prepErr := session.RunWhile(termui.Progress{Phase: termui.PhasePrepare}, func() error {
-			if cfgMissing {
-				session.Warn("No prof.json found; proceeding without function filters (run prof config init to add one).")
+			if cfgMissing && !opts.MissingConfigWarnShown {
+				session.Warn(config.MissingConfigUserWarning)
 			}
 			if graphvizMissing {
 				session.Warn(tooling.SkipPNGNotice)

--- a/engine/collect/options.go
+++ b/engine/collect/options.go
@@ -4,10 +4,11 @@ package collect
 
 // AutoOptions configures RunAuto.
 type AutoOptions struct {
-	Benchmarks []string
-	Profiles   []string
-	Tag        string
-	Count      int
+	Benchmarks             []string
+	Profiles               []string
+	Tag                    string
+	Count                  int
+	MissingConfigWarnShown bool // survey already printed config.MissingConfigUserWarning
 }
 
 // ManualOptions configures RunManual.

--- a/engine/collect/profiles.go
+++ b/engine/collect/profiles.go
@@ -72,7 +72,7 @@ func warnMissingProfile(session *termui.Session, profileFile string) {
 }
 
 func warnSkippedPNG(session *termui.Session, profile, benchmarkName string, pngErr error) {
-	msg := fmt.Sprintf("PNG skipped for %s/%s: %v", benchmarkName, profile, pngErr)
+	msg := fmt.Sprintf("PNG skipped for %s/%s", benchmarkName, profile)
 	if session.Interactive() {
 		session.Warn(msg)
 		return

--- a/internal/app/dto.go
+++ b/internal/app/dto.go
@@ -2,10 +2,11 @@ package app
 
 // CollectAutoOptions describes a prof auto run.
 type CollectAutoOptions struct {
-	Benchmarks []string
-	Profiles   []string
-	Tag        string
-	Count      int
+	Benchmarks             []string
+	Profiles               []string
+	Tag                    string
+	Count                  int
+	MissingConfigWarnShown bool // survey already printed MissingConfigUserWarning
 }
 
 // CollectManualOptions describes a prof manual ingest run.

--- a/internal/config/const.go
+++ b/internal/config/const.go
@@ -7,4 +7,6 @@ const (
 	ExampleFilename = "prof.json.example"
 	// CurrentVersion is the supported prof.json schema version.
 	CurrentVersion = 1
+	// MissingConfigUserWarning is shown when prof.json is absent during collect.
+	MissingConfigUserWarning = "No prof.json found; proceeding without function filters (run prof config init to add one)."
 )

--- a/internal/intent/collect.go
+++ b/internal/intent/collect.go
@@ -9,10 +9,11 @@ import (
 
 // CollectIntent mirrors prof auto / prof tui collect → Collect.RunAuto.
 type CollectIntent struct {
-	Benchmarks []string
-	Profiles   []string
-	Tag        string
-	Count      int
+	Benchmarks             []string
+	Profiles               []string
+	Tag                    string
+	Count                  int
+	MissingConfigWarnShown bool
 }
 
 // Kind implements [Executable].
@@ -45,10 +46,11 @@ func (i *CollectIntent) Validate() error {
 // Run implements [Executable].
 func (i *CollectIntent) Run(svc *app.Services) error {
 	return svc.Collect.RunAuto(app.CollectAutoOptions{
-		Benchmarks: i.Benchmarks,
-		Profiles:   i.Profiles,
-		Tag:        i.Tag,
-		Count:      i.Count,
+		Benchmarks:             i.Benchmarks,
+		Profiles:               i.Profiles,
+		Tag:                    i.Tag,
+		Count:                  i.Count,
+		MissingConfigWarnShown: i.MissingConfigWarnShown,
 	})
 }
 

--- a/internal/termui/progress.go
+++ b/internal/termui/progress.go
@@ -137,11 +137,12 @@ func phasePrefixes(phase Phase) (linePrefix, warnPrefix string) {
 	return "  ", "      "
 }
 
-// BeginCollect prints a section break before the prepare stage (interactive only).
+// BeginCollect plays a short transition then prints the collect section header.
 func (s *Session) BeginCollect() {
 	if s == nil || !s.interactive {
 		return
 	}
+	PrintTransition(s.w, s.fd, CollectSectionTitle)
 	PrintSection(s.w, s.fd, CollectSectionTitle)
 }
 

--- a/internal/termui/progress.go
+++ b/internal/termui/progress.go
@@ -351,7 +351,7 @@ func (s *Session) overwriteLineLocked(content string, newline bool) {
 }
 
 func formatWarningLine(prefix, msg string) string {
-	return WarningPrefixStyle.Render(prefix+"warning: ") + WarningStyle.Render(msg)
+	return FormatWarningLine(prefix, msg)
 }
 
 // StageDetailKind identifies a stage-scoped diagnostic line.

--- a/internal/termui/progress.go
+++ b/internal/termui/progress.go
@@ -392,11 +392,9 @@ func shortUserMessage(err error) string {
 
 func (s *Session) writeStageDetailLinesLocked(kind StageDetailKind, msg string) {
 	for _, line := range splitDetailMessage(msg) {
-		formatted := truncateDetailLine(kind, s.warnPrefix, line, s.termWidth())
-		fmt.Fprintln(s.w, formatted)
-		s.detailLines++
-		if kind == StageWarn {
-			s.warnCount++
+		for _, formatted := range wrapDetailLines(kind, s.warnPrefix, line, s.termWidth()) {
+			fmt.Fprintln(s.w, formatted)
+			s.detailLines++
 		}
 	}
 }
@@ -416,19 +414,127 @@ func splitDetailMessage(msg string) []string {
 	return lines
 }
 
-func truncateDetailLine(kind StageDetailKind, prefix, msg string, maxWidth int) string {
-	const ellipsis = "…"
-	runes := []rune(msg)
-	for {
-		candidate := formatStageDetailLine(kind, prefix, string(runes))
-		if lipgloss.Width(candidate) <= maxWidth {
-			return candidate
-		}
-		if len(runes) == 0 {
-			return formatStageDetailLine(kind, prefix, ellipsis)
-		}
-		runes = runes[:len(runes)-1]
+func stageDetailHead(kind StageDetailKind, prefix string) string {
+	switch kind {
+	case StageError:
+		return ErrorPrefixStyle.Render(prefix + "error: ")
+	default:
+		return WarningPrefixStyle.Render(prefix + "warning: ")
 	}
+}
+
+func stageDetailBodyStyle(kind StageDetailKind) lipgloss.Style {
+	switch kind {
+	case StageError:
+		return ErrorStyle
+	default:
+		return WarningStyle
+	}
+}
+
+// wrapDetailLines splits a long diagnostic into terminal-width lines. The first
+// line includes the styled prefix; continuations align under the message text.
+func wrapDetailLines(kind StageDetailKind, prefix, msg string, maxWidth int) []string {
+	full := formatStageDetailLine(kind, prefix, msg)
+	if maxWidth <= 0 || lipgloss.Width(full) <= maxWidth {
+		return []string{full}
+	}
+
+	head := stageDetailHead(kind, prefix)
+	headWidth := lipgloss.Width(head)
+	bodyStyle := stageDetailBodyStyle(kind)
+	contPad := strings.Repeat(" ", headWidth)
+
+	firstMax := maxWidth - headWidth
+	if firstMax < 1 {
+		firstMax = 1
+	}
+	contMax := maxWidth - headWidth
+	if contMax < 1 {
+		contMax = 1
+	}
+
+	var lines []string
+	remaining := strings.TrimSpace(msg)
+	first := true
+	for remaining != "" {
+		limit := contMax
+		if first {
+			limit = firstMax
+		}
+		chunk, rest := takeWrappedChunk(remaining, limit)
+		if chunk == "" {
+			break
+		}
+		body := bodyStyle.Render(chunk)
+		if first {
+			lines = append(lines, head+body)
+			first = false
+		} else {
+			lines = append(lines, contPad+body)
+		}
+		remaining = strings.TrimSpace(rest)
+	}
+	if len(lines) == 0 {
+		return []string{full}
+	}
+	return lines
+}
+
+// takeWrappedChunk returns the largest prefix of text that fits in limit visible
+// columns, preferring word boundaries; a single overlong word is hard-broken.
+func takeWrappedChunk(text string, limit int) (chunk, rest string) {
+	if limit <= 0 {
+		return "", text
+	}
+	text = strings.TrimLeft(text, " ")
+	if text == "" {
+		return "", ""
+	}
+	if runeWidth(text) <= limit {
+		return text, ""
+	}
+
+	words := strings.Fields(text)
+	if len(words) == 0 {
+		return hardBreakRunes(text, limit)
+	}
+
+	var b strings.Builder
+	for i, word := range words {
+		sep := ""
+		if b.Len() > 0 {
+			sep = " "
+		}
+		candidate := sep + word
+		if runeWidth(candidate) > limit && b.Len() == 0 {
+			return hardBreakRunes(word, limit)
+		}
+		if runeWidth(b.String()+candidate) > limit {
+			restWords := words[i:]
+			return strings.TrimSpace(b.String()), strings.Join(restWords, " ")
+		}
+		b.WriteString(candidate)
+	}
+	return b.String(), ""
+}
+
+func runeWidth(s string) int {
+	return lipgloss.Width(s)
+}
+
+func hardBreakRunes(text string, limit int) (chunk, rest string) {
+	runes := []rune(text)
+	if len(runes) == 0 {
+		return "", ""
+	}
+	for n := len(runes); n > 0; n-- {
+		part := string(runes[:n])
+		if runeWidth(part) <= limit {
+			return part, string(runes[n:])
+		}
+	}
+	return string(runes[:1]), string(runes[1:])
 }
 
 func (s *Session) captureStageErrorLocked(err error) {
@@ -465,6 +571,9 @@ func (s *Session) stageDetail(kind StageDetailKind, msg string) {
 
 	s.lockHeaderLocked()
 	s.writeStageDetailLinesLocked(kind, msg)
+	if kind == StageWarn {
+		s.warnCount++
+	}
 	if kind == StageError {
 		s.errorDetailEmitted = true
 		s.errorDisplayed = true

--- a/internal/termui/progress.go
+++ b/internal/termui/progress.go
@@ -392,10 +392,8 @@ func shortUserMessage(err error) string {
 
 func (s *Session) writeStageDetailLinesLocked(kind StageDetailKind, msg string) {
 	for _, line := range splitDetailMessage(msg) {
-		for _, formatted := range wrapDetailLines(kind, s.warnPrefix, line, s.termWidth()) {
-			fmt.Fprintln(s.w, formatted)
-			s.detailLines++
-		}
+		fmt.Fprintln(s.w, formatStageDetailLine(kind, s.warnPrefix, line))
+		s.detailLines++
 	}
 }
 
@@ -412,129 +410,6 @@ func splitDetailMessage(msg string) []string {
 		return []string{msg}
 	}
 	return lines
-}
-
-func stageDetailHead(kind StageDetailKind, prefix string) string {
-	switch kind {
-	case StageError:
-		return ErrorPrefixStyle.Render(prefix + "error: ")
-	default:
-		return WarningPrefixStyle.Render(prefix + "warning: ")
-	}
-}
-
-func stageDetailBodyStyle(kind StageDetailKind) lipgloss.Style {
-	switch kind {
-	case StageError:
-		return ErrorStyle
-	default:
-		return WarningStyle
-	}
-}
-
-// wrapDetailLines splits a long diagnostic into terminal-width lines. The first
-// line includes the styled prefix; continuations align under the message text.
-func wrapDetailLines(kind StageDetailKind, prefix, msg string, maxWidth int) []string {
-	full := formatStageDetailLine(kind, prefix, msg)
-	if maxWidth <= 0 || lipgloss.Width(full) <= maxWidth {
-		return []string{full}
-	}
-
-	head := stageDetailHead(kind, prefix)
-	headWidth := lipgloss.Width(head)
-	bodyStyle := stageDetailBodyStyle(kind)
-	contPad := strings.Repeat(" ", headWidth)
-
-	firstMax := maxWidth - headWidth
-	if firstMax < 1 {
-		firstMax = 1
-	}
-	contMax := maxWidth - headWidth
-	if contMax < 1 {
-		contMax = 1
-	}
-
-	var lines []string
-	remaining := strings.TrimSpace(msg)
-	first := true
-	for remaining != "" {
-		limit := contMax
-		if first {
-			limit = firstMax
-		}
-		chunk, rest := takeWrappedChunk(remaining, limit)
-		if chunk == "" {
-			break
-		}
-		body := bodyStyle.Render(chunk)
-		if first {
-			lines = append(lines, head+body)
-			first = false
-		} else {
-			lines = append(lines, contPad+body)
-		}
-		remaining = strings.TrimSpace(rest)
-	}
-	if len(lines) == 0 {
-		return []string{full}
-	}
-	return lines
-}
-
-// takeWrappedChunk returns the largest prefix of text that fits in limit visible
-// columns, preferring word boundaries; a single overlong word is hard-broken.
-func takeWrappedChunk(text string, limit int) (chunk, rest string) {
-	if limit <= 0 {
-		return "", text
-	}
-	text = strings.TrimLeft(text, " ")
-	if text == "" {
-		return "", ""
-	}
-	if runeWidth(text) <= limit {
-		return text, ""
-	}
-
-	words := strings.Fields(text)
-	if len(words) == 0 {
-		return hardBreakRunes(text, limit)
-	}
-
-	var b strings.Builder
-	for i, word := range words {
-		sep := ""
-		if b.Len() > 0 {
-			sep = " "
-		}
-		candidate := sep + word
-		if runeWidth(candidate) > limit && b.Len() == 0 {
-			return hardBreakRunes(word, limit)
-		}
-		if runeWidth(b.String()+candidate) > limit {
-			restWords := words[i:]
-			return strings.TrimSpace(b.String()), strings.Join(restWords, " ")
-		}
-		b.WriteString(candidate)
-	}
-	return b.String(), ""
-}
-
-func runeWidth(s string) int {
-	return lipgloss.Width(s)
-}
-
-func hardBreakRunes(text string, limit int) (chunk, rest string) {
-	runes := []rune(text)
-	if len(runes) == 0 {
-		return "", ""
-	}
-	for n := len(runes); n > 0; n-- {
-		part := string(runes[:n])
-		if runeWidth(part) <= limit {
-			return part, string(runes[n:])
-		}
-	}
-	return string(runes[:1]), string(runes[1:])
 }
 
 func (s *Session) captureStageErrorLocked(err error) {

--- a/internal/termui/progress.go
+++ b/internal/termui/progress.go
@@ -142,15 +142,7 @@ func (s *Session) BeginCollect() {
 	if s == nil || !s.interactive {
 		return
 	}
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	fmt.Fprintln(s.w)
-	fmt.Fprintln(s.w, BenchmarkTitleStyle.Render(CollectSectionTitle))
-	width := s.termWidth()
-	fmt.Fprintln(s.w, SectionRuleStyle.Render(strings.Repeat("─", width)))
-	fmt.Fprintln(s.w)
+	PrintSection(s.w, s.fd, CollectSectionTitle)
 }
 
 // BeginBenchmark prints a section header before the three steps for one benchmark.

--- a/internal/termui/progress_test.go
+++ b/internal/termui/progress_test.go
@@ -159,6 +159,23 @@ func TestSession_PreparingThenBenchmark(t *testing.T) {
 	}
 }
 
+func TestPrintSection_writesTitleAndRule(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	PrintSection(&buf, -1, SurveySectionTitle)
+	out := buf.String()
+	if !strings.HasPrefix(out, "\n") {
+		t.Fatalf("expected leading blank line: %q", out)
+	}
+	if !strings.Contains(out, SurveySectionTitle) {
+		t.Fatalf("missing title: %q", out)
+	}
+	if !strings.Contains(out, "─") {
+		t.Fatalf("missing rule: %q", out)
+	}
+}
+
 func TestSession_BeginCollect_printsSectionBreak(t *testing.T) {
 	t.Parallel()
 

--- a/internal/termui/progress_test.go
+++ b/internal/termui/progress_test.go
@@ -429,12 +429,12 @@ func TestSession_RunWhile_warnedSuccessShowsCountSuffix(t *testing.T) {
 	}
 }
 
-func TestSession_Warn_truncatesOnNarrowTerminal(t *testing.T) {
+func TestSession_Warn_wrapsOnNarrowTerminal(t *testing.T) {
 	t.Parallel()
 
 	var buf bytes.Buffer
 	s := newNarrowSessionForTest(&buf, 36)
-	longMsg := strings.Repeat("x", 80)
+	longMsg := strings.Repeat("word ", 20)
 	err := s.RunWhile(Progress{Phase: PhasePrepare}, func() error {
 		s.Warn(longMsg)
 		return nil
@@ -443,11 +443,17 @@ func TestSession_Warn_truncatesOnNarrowTerminal(t *testing.T) {
 		t.Fatalf("RunWhile() err = %v", err)
 	}
 	out := buf.String()
-	if strings.Count(out, longMsg) > 0 {
-		t.Fatalf("expected truncated message, got full repeat in %q", out)
+	if !strings.Contains(out, "warning:") {
+		t.Fatalf("expected warning prefix: %q", out)
+	}
+	if strings.Count(out, "warning:") != 1 {
+		t.Fatalf("expected single warning prefix on first line: %q", out)
+	}
+	if strings.Count(out, "\n") < 2 {
+		t.Fatalf("expected wrapped warning across multiple lines: %q", out)
 	}
 	if !strings.Contains(out, "✓") {
-		t.Fatalf("expected success marker after truncate: %q", out)
+		t.Fatalf("expected success marker after wrap: %q", out)
 	}
 }
 

--- a/internal/termui/progress_test.go
+++ b/internal/termui/progress_test.go
@@ -429,12 +429,12 @@ func TestSession_RunWhile_warnedSuccessShowsCountSuffix(t *testing.T) {
 	}
 }
 
-func TestSession_Warn_wrapsOnNarrowTerminal(t *testing.T) {
+func TestSession_Warn_keepsFullLineOnNarrowTerminal(t *testing.T) {
 	t.Parallel()
 
 	var buf bytes.Buffer
 	s := newNarrowSessionForTest(&buf, 36)
-	longMsg := strings.Repeat("word ", 20)
+	longMsg := strings.TrimSpace(strings.Repeat("word ", 20))
 	err := s.RunWhile(Progress{Phase: PhasePrepare}, func() error {
 		s.Warn(longMsg)
 		return nil
@@ -443,17 +443,14 @@ func TestSession_Warn_wrapsOnNarrowTerminal(t *testing.T) {
 		t.Fatalf("RunWhile() err = %v", err)
 	}
 	out := buf.String()
-	if !strings.Contains(out, "warning:") {
-		t.Fatalf("expected warning prefix: %q", out)
+	if !strings.Contains(out, longMsg) {
+		t.Fatalf("expected full warning on one line: %q", out)
 	}
 	if strings.Count(out, "warning:") != 1 {
-		t.Fatalf("expected single warning prefix on first line: %q", out)
-	}
-	if strings.Count(out, "\n") < 2 {
-		t.Fatalf("expected wrapped warning across multiple lines: %q", out)
+		t.Fatalf("expected single warning prefix: %q", out)
 	}
 	if !strings.Contains(out, "✓") {
-		t.Fatalf("expected success marker after wrap: %q", out)
+		t.Fatalf("expected success marker: %q", out)
 	}
 }
 

--- a/internal/termui/progress_test.go
+++ b/internal/termui/progress_test.go
@@ -159,6 +159,16 @@ func TestSession_PreparingThenBenchmark(t *testing.T) {
 	}
 }
 
+func TestStepGap_writesBlankLine(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	StepGap(&buf)
+	if buf.String() != "\n" {
+		t.Fatalf("StepGap() = %q, want newline", buf.String())
+	}
+}
+
 func TestPrintSection_writesTitleAndRule(t *testing.T) {
 	t.Parallel()
 

--- a/internal/termui/progress_test.go
+++ b/internal/termui/progress_test.go
@@ -163,7 +163,7 @@ func TestPrintWarning_writesStyledLine(t *testing.T) {
 	t.Parallel()
 
 	var buf bytes.Buffer
-	PrintWarning(&buf, ConfigureDetailPrefix, "oops")
+	PrintWarning(&buf, ConfigureWarningPrefix, "oops")
 	if !strings.Contains(buf.String(), "warning:") {
 		t.Fatalf("output = %q", buf.String())
 	}

--- a/internal/termui/progress_test.go
+++ b/internal/termui/progress_test.go
@@ -159,6 +159,16 @@ func TestSession_PreparingThenBenchmark(t *testing.T) {
 	}
 }
 
+func TestPrintWarning_writesStyledLine(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	PrintWarning(&buf, ConfigureDetailPrefix, "oops")
+	if !strings.Contains(buf.String(), "warning:") {
+		t.Fatalf("output = %q", buf.String())
+	}
+}
+
 func TestStepGap_writesBlankLine(t *testing.T) {
 	t.Parallel()
 

--- a/internal/termui/section.go
+++ b/internal/termui/section.go
@@ -11,7 +11,11 @@ import (
 // SurveySectionTitle is the heading printed before interactive collect prompts.
 const SurveySectionTitle = "Configure collection"
 
-// ConfigureDetailPrefix indents warnings in the configure-collection section.
+// ConfigureWarningPrefix is the left margin for warnings in the configure-collection section.
+// Survey questions start at column 0, so warnings align with them.
+const ConfigureWarningPrefix = ""
+
+// ConfigureDetailPrefix indents detail lines under a configure-collection stage header.
 const ConfigureDetailPrefix = "    "
 
 // FormatWarningLine renders a styled warning line for interactive terminals.

--- a/internal/termui/section.go
+++ b/internal/termui/section.go
@@ -1,0 +1,39 @@
+package termui
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"golang.org/x/term"
+)
+
+// SurveySectionTitle is the heading printed before interactive collect prompts.
+const SurveySectionTitle = "Configure collection"
+
+// PrintSection writes a titled section break: blank line, bold title, faint rule, blank line.
+func PrintSection(w io.Writer, fd int, title string) {
+	if w == nil || title == "" {
+		return
+	}
+
+	width := defaultTermWidth
+	if fd >= 0 {
+		if _, tw, err := term.GetSize(fd); err == nil && tw > 0 {
+			width = tw
+		}
+	}
+
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, BenchmarkTitleStyle.Render(title))
+	fmt.Fprintln(w, SectionRuleStyle.Render(strings.Repeat("─", width)))
+	fmt.Fprintln(w)
+}
+
+// EndSection prints a trailing blank line after a section's content.
+func EndSection(w io.Writer) {
+	if w == nil {
+		return
+	}
+	fmt.Fprintln(w)
+}

--- a/internal/termui/section.go
+++ b/internal/termui/section.go
@@ -4,7 +4,11 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
+	"github.com/charmbracelet/bubbles/spinner"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 	"golang.org/x/term"
 )
 
@@ -61,4 +65,46 @@ func StepGap(w io.Writer) {
 // EndSection prints a trailing blank line after a section's content.
 func EndSection(w io.Writer) {
 	StepGap(w)
+}
+
+const collectTransitionDuration = 500 * time.Millisecond
+
+var sectionSpinner = spinner.Dot
+
+// PrintTransition shows a brief in-place spinner while handing off to the collect pipeline.
+func PrintTransition(w io.Writer, fd int, message string) {
+	if w == nil || message == "" {
+		return
+	}
+	if fd >= 0 && !term.IsTerminal(fd) {
+		return
+	}
+
+	width := defaultTermWidth
+	if fd >= 0 {
+		if _, tw, err := term.GetSize(fd); err == nil && tw > 0 {
+			width = tw
+		}
+	}
+
+	frames := sectionSpinner.Frames
+	ticker := time.NewTicker(sectionSpinner.FPS)
+	defer ticker.Stop()
+
+	deadline := time.Now().Add(collectTransitionDuration)
+	label := message + "…"
+	i := 0
+	for time.Now().Before(deadline) {
+		frame := frames[i%len(frames)]
+		content := spinnerFrameStyle.Render(frame) + " " + LabelStyle.Render(label)
+		visible := lipgloss.Width(content)
+		padding := width - visible
+		if padding < 0 {
+			padding = 0
+		}
+		fmt.Fprint(w, "\r"+content+strings.Repeat(" ", padding))
+		i++
+		<-ticker.C
+	}
+	fmt.Fprint(w, ansi.EraseEntireLine+"\r")
 }

--- a/internal/termui/section.go
+++ b/internal/termui/section.go
@@ -11,6 +11,22 @@ import (
 // SurveySectionTitle is the heading printed before interactive collect prompts.
 const SurveySectionTitle = "Configure collection"
 
+// ConfigureDetailPrefix indents warnings in the configure-collection section.
+const ConfigureDetailPrefix = "    "
+
+// FormatWarningLine renders a styled warning line for interactive terminals.
+func FormatWarningLine(prefix, msg string) string {
+	return WarningPrefixStyle.Render(prefix+"warning: ") + WarningStyle.Render(msg)
+}
+
+// PrintWarning writes one styled warning line to w.
+func PrintWarning(w io.Writer, prefix, msg string) {
+	if w == nil {
+		return
+	}
+	fmt.Fprintln(w, FormatWarningLine(prefix, msg))
+}
+
 // PrintSection writes a titled section break: blank line, bold title, faint rule, blank line.
 func PrintSection(w io.Writer, fd int, title string) {
 	if w == nil || title == "" {

--- a/internal/termui/section.go
+++ b/internal/termui/section.go
@@ -30,10 +30,15 @@ func PrintSection(w io.Writer, fd int, title string) {
 	fmt.Fprintln(w)
 }
 
-// EndSection prints a trailing blank line after a section's content.
-func EndSection(w io.Writer) {
+// StepGap prints a blank line between steps in a multi-step terminal flow.
+func StepGap(w io.Writer) {
 	if w == nil {
 		return
 	}
 	fmt.Fprintln(w)
+}
+
+// EndSection prints a trailing blank line after a section's content.
+func EndSection(w io.Writer) {
+	StepGap(w)
 }

--- a/internal/tui/hub.go
+++ b/internal/tui/hub.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -62,6 +63,8 @@ func RunMainMenu() (MainAction, error) {
 	if err != nil {
 		return MainNone, err
 	}
+	// Bubble Tea may leave the cursor hidden after alt-screen; survey needs it visible.
+	fmt.Fprint(os.Stdout, "\033[?25h")
 	fm, ok := final.(*hubModel)
 	if !ok {
 		return MainNone, fmt.Errorf("internal error: unexpected model type %T", final)


### PR DESCRIPTION
## Summary

- Add a **Configure collection** section around the survey wizard with styled warnings that match the collect pipeline; blank lines appear only after warnings/errors, not between every prompt.
- Replace survey \Input\ for count/tag with styled line prompts to fix Windows blank-line and echo issues while keeping the green bold \?\ marker.
- Add a brief spinner transition before the **Collecting profiles** section when the pipeline starts.
- Deduplicate the missing \prof.json\ warning when the survey already showed it during benchmark selection.
- Print collect-stage warnings as single full lines (no manual wrapping); simplify per-profile PNG skip messages now that Graphviz is explained in Prepare.
- Restore the cursor after the Bubble Tea hub exits so survey prompts render correctly.

## Test plan

- [ ] \go test ./...\
- [ ] \go run ./cmd/prof ui\ — run collect with and without \prof.json\; confirm configure spacing, no duplicate config warning, spinner handoff, and full-line stage warnings
- [ ] Verify count/tag prompts have green \?\ and no extra blank lines between consecutive questions
- [ ] Confirm PNG failures show \PNG skipped for <bench>/<profile>\ without a dangling colon

Made with [Cursor](https://cursor.com)