### PR TITLE
feat: write collect output under .prof instead of bench

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ tasks.md
 /prof.exe
 
 # Runtime profiling output (prof auto / prof tui); example benchmarks live in benchmarks/
+/.prof/
 /bench/
 
 # Release builds

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -125,7 +125,7 @@ linters-settings:
           - pkg: "github.com/AlexsanderHamir/prof/cli"
           - pkg: "github.com/AlexsanderHamir/prof/engine"
           - pkg: "github.com/AlexsanderHamir/prof/internal/workspace"
-            desc: "parser decodes profiles; it does not know bench/ layout."
+            desc: "parser decodes profiles; it does not know .prof/ layout."
       "layering-exec":
         files:
           - "cli/**"

--- a/CODEBASE_DESIGN.md
+++ b/CODEBASE_DESIGN.md
@@ -15,7 +15,7 @@
 1. **See how packages depend on each other** → [How packages connect at runtime](#how-packages-connect-at-runtime)
 2. **Look up what a directory is for** → [Package layout (by path)](#package-layout-by-path)
 3. **Change a command or UI flow** → [How to find the code for each command](#how-to-find-the-code-for-each-command)
-4. **Change on-disk output or JSON / pipeline behavior** → [Profile pipelines](#profile-pipelines), [Output layout under `bench/`](#output-layout-under-bench), [Configuration](#configuration-profjson)
+4. **Change on-disk output or JSON / pipeline behavior** → [Profile pipelines](#profile-pipelines), [Output layout under `.prof/`](#output-layout-under-prof), [Configuration](#configuration-profjson)
 5. **Avoid surprises** → [Invariants](#invariants), [Edge-case catalog](#edge-case-catalog), [Testing and lint policy](#testing-and-lint-policy)
 
 ## How packages connect at runtime
@@ -99,19 +99,19 @@ Benchmark discovery: [`engine/collect/discovery.go`](engine/collect/discovery.go
 ### Automated benchmark (`prof auto`)
 
 1. [`collect.RunAuto`](engine/collect/entry.go) loads optional `prof.json` via [`config.Load`](internal/config/load.go).
-2. Creates `bench/<tag>/` via [`collect/layout.go`](engine/collect/layout.go) and [`workspace.CleanOrCreateTag`](internal/workspace/tag.go).
+2. Creates `.prof/<tag>/` via [`collect/layout.go`](engine/collect/layout.go) and [`workspace.CleanOrCreateTag`](internal/workspace/tag.go).
 3. Per benchmark, three TTY-gated stderr steps via [`termui.Session`](internal/termui/progress.go) in [`pipeline.go`](engine/collect/pipeline.go), preceded by a **Preparing** stage in [`entry.go`](engine/collect/entry.go): **Running benchmark** (`go test` + artifact move), **Collecting profiles** ([`processProfiles`](engine/collect/profiles.go)), **Collecting function profiles** (parser + per-function `pprof -list`). Interactive TTY keeps a persistent stage log (`✓` done lines + stage-scoped warnings); non-TTY keeps `slog` stage logs.
 
 ### Manual ingest (`prof manual`)
 
 [`collect.RunManual`](engine/collect/manual.go): cleans tag dir, copies binaries into auto layout, emits the same artifact types. Does not run `go test`.
 
-## Output layout under `bench/`
+## Output layout under `.prof/`
 
 All paths come from [`workspace.TagLayout`](internal/workspace/layout.go):
 
 ```text
-bench/
+.prof/
 └── <tag>/
     ├── notes.txt
     ├── profiles/<BenchmarkName>/<profile>.out

--- a/cli/cmd_collect.go
+++ b/cli/cmd_collect.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/AlexsanderHamir/prof/internal/app"
+	"github.com/AlexsanderHamir/prof/internal/workspace"
 	"github.com/spf13/cobra"
 )
 
@@ -22,7 +23,7 @@ func newManualCollectCmd(svc *app.Services) *cobra.Command {
 	f := &manualCollectFlags{}
 	cmd := &cobra.Command{
 		Use:     CmdManual,
-		Short:   "Ingest existing pprof profile binaries and organize them under bench/<tag>/ (does not run go test).",
+		Short:   fmt.Sprintf("Ingest existing pprof profile binaries and organize them under %s/<tag>/ (does not run go test).", workspace.MainDirOutput),
 		Args:    cobra.MinimumNArgs(1),
 		Example: fmt.Sprintf("prof %s --tag tagName cpu.prof memory.prof block.prof mutex.prof", CmdManual),
 		RunE: func(_ *cobra.Command, args []string) error {

--- a/cli/root.go
+++ b/cli/root.go
@@ -1,7 +1,10 @@
 package cli
 
 import (
+	"fmt"
+
 	"github.com/AlexsanderHamir/prof/internal/app"
+	"github.com/AlexsanderHamir/prof/internal/workspace"
 	"github.com/spf13/cobra"
 )
 
@@ -17,9 +20,9 @@ func CreateRootCmd(services *app.Services) *cobra.Command {
 
 	root := &cobra.Command{
 		Use:   "prof",
-		Short: "Go benchmark profiling: collect pprof-backed runs under bench/<tag>/.",
-		Long: `Prof wraps go test and pprof so you can capture CPU, memory, mutex, and block profiles in one
-workflow and store artifacts in a predictable bench/<tag>/ tree.
+		Short: fmt.Sprintf("Go benchmark profiling: collect pprof-backed runs under %s/<tag>/.", workspace.MainDirOutput),
+		Long: fmt.Sprintf(`Prof wraps go test and pprof so you can capture CPU, memory, mutex, and block profiles in one
+workflow and store artifacts in a predictable %s/<tag>/ tree.
 
 Start interactively (no flags to memorize):
 
@@ -27,7 +30,7 @@ Start interactively (no flags to memorize):
 
 For automation, use prof auto, prof manual, and other subcommands — see prof -h and prof <command> -h.
 
-Documentation: https://alexsanderhamir.github.io/prof/`,
+Documentation: https://alexsanderhamir.github.io/prof/`, workspace.MainDirOutput),
 		Example: `  # Guided menu (recommended first run)
   prof ui
 

--- a/cli/tui.go
+++ b/cli/tui.go
@@ -11,6 +11,7 @@ import (
 	"github.com/AlexsanderHamir/prof/internal/app"
 	"github.com/AlexsanderHamir/prof/internal/intent"
 	"github.com/AlexsanderHamir/prof/internal/termui"
+	"github.com/AlexsanderHamir/prof/internal/workspace"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 )
@@ -68,7 +69,7 @@ func runTUI(svc *app.Services, _ *cobra.Command, _ []string) error {
 		return fmt.Errorf("invalid count: %s", countStr)
 	}
 
-	tagStr, err := askConfigureLine(reader, os.Stdout, "Tag name (used to group results under bench/<tag>):", "")
+	tagStr, err := askConfigureLine(reader, os.Stdout, fmt.Sprintf("Tag name (used to group results under %s/<tag>):", workspace.MainDirOutput), "")
 	if err != nil {
 		return err
 	}

--- a/docs/collect-request-flow.md
+++ b/docs/collect-request-flow.md
@@ -14,7 +14,7 @@ This page traces what happens **inside prof** when you run interactive benchmark
 
 ## Before you begin
 
-- You know Go module layout and that prof writes under `bench/<tag>/`.
+- You know Go module layout and that prof writes under `.prof/<tag>/`.
 - For installing and running prof as a user, read [readme.md](../readme.md) and [prof_web_doc/docs/tui.md](../prof_web_doc/docs/tui.md).
 - For package boundaries and invariants, read [CODEBASE_DESIGN.md](../CODEBASE_DESIGN.md).
 
@@ -79,11 +79,11 @@ Each Survey step maps to a function, validation rule, and field on [`CollectInte
 
 | Prompt | Effect |
 | --- | --- |
-| Select benchmarks | Regex scan of `*_test.go` under cwd; skips `vendor`, `bench`, `tests`, and nested `go.mod` trees |
+| Select benchmarks | Regex scan of `*_test.go` under cwd; skips dot-prefixed dirs, `vendor`, `bench` (legacy), `tests`, and nested `go.mod` trees |
 | Collection filters line | Read-only preview via `config.Load` + `ResolveCollectionFilter`; does not block the run |
 | Select profiles | Profile IDs from [`engine/tooling/catalog.go`](../engine/tooling/catalog.go) |
 | Number of runs | Rejects count `< 1` in `runTUI` before intent validation |
-| Tag name | Trimmed tag becomes `bench/<tag>/` via [`workspace.TagLayout`](../internal/workspace/layout.go) |
+| Tag name | Trimmed tag becomes `.prof/<tag>/` via [`workspace.TagLayout`](../internal/workspace/layout.go) |
 
 `CollectIntent.Run` copies fields into `app.CollectAutoOptions` ([`internal/app/dto.go`](../internal/app/dto.go)) before calling `collect.RunAuto`.
 
@@ -121,7 +121,7 @@ flowchart TB
 
 [`setupDirectories`](../engine/collect/layout.go) (inside **Preparing** on TTY, or before config print on non-TTY):
 
-- Resolves `bench/<tag>/` with [`workspace.CleanOrCreateTag`](../internal/workspace/tag.go).
+- Resolves `.prof/<tag>/` with [`workspace.CleanOrCreateTag`](../internal/workspace/tag.go).
 - Creates `profiles/<benchmark>/`, `measurements/<benchmark>/`, `hotspots/<benchmark>/`, `source_lines/<profile>/<benchmark>/`, and `notes.txt`.
 
 ### 3–5. Per-benchmark progress (TTY)
@@ -165,7 +165,7 @@ For `BenchmarkMatrixMultiplication`, [`runBenchmark`](../engine/collect/gotest.g
 - Locates the package directory containing the benchmark function.
 - Builds `go test -run=^$ -bench=^BenchmarkMatrixMultiplication$ -benchmem -count=5` plus profile flags from the tooling catalog (`cpu`, `memory`).
 - Runs the command in the benchmark package directory via [`tooling.Runner`](../engine/tooling/runner.go).
-- Writes combined benchmark output to `measurements/<benchmark>/run.txt`; moves profile binaries (`.out`) into `bench/Baseline/profiles/BenchmarkMatrixMultiplication/`. Failures return combined output in the error.
+- Writes combined benchmark output to `measurements/<benchmark>/run.txt`; moves profile binaries (`.out`) into `.prof/baseline/profiles/BenchmarkMatrixMultiplication/`. Failures return combined output in the error.
 
 #### Step 2 — Process profiles
 
@@ -193,7 +193,7 @@ When all benchmarks finish, prof logs collection success and returns.
 All paths come from [`workspace.TagLayout`](../internal/workspace/layout.go). For the running example:
 
 ```text
-bench/
+.prof/
 └── Baseline/
     ├── notes.txt
     ├── profiles/BenchmarkMatrixMultiplication/

--- a/engine/collect/doc.go
+++ b/engine/collect/doc.go
@@ -1,4 +1,4 @@
-// Package collect runs auto and manual profile collection under bench/<tag>/.
+// Package collect runs auto and manual profile collection under .prof/<tag>/.
 // Artifacts are grouped by data domain: profiles, measurements, hotspots,
 // source_lines, and call_graphs (see internal/workspace.TagLayout).
 package collect

--- a/engine/collect/manual.go
+++ b/engine/collect/manual.go
@@ -13,7 +13,7 @@ import (
 	"github.com/AlexsanderHamir/prof/parser"
 )
 
-// RunManual organizes manual profile files under bench/<tag>/ using the auto layout.
+// RunManual organizes manual profile files under .prof/<tag>/ using the auto layout.
 func RunManual(runner tooling.Runner, opts ManualOptions) error {
 	if runner == nil {
 		return errors.New("tooling runner is nil")

--- a/engine/collect/options.go
+++ b/engine/collect/options.go
@@ -1,4 +1,4 @@
-// Package collect runs prof auto (go test) and prof manual (ingest) pipelines under bench/<tag>/.
+// Package collect runs prof auto (go test) and prof manual (ingest) pipelines under .prof/<tag>/.
 // Output domains: profiles/, measurements/, hotspots/, source_lines/, call_graphs/.
 package collect
 

--- a/engine/tooling/catalog.go
+++ b/engine/tooling/catalog.go
@@ -87,7 +87,7 @@ func (c *Catalog) GoTestProfileArgs(ids []string) ([]string, error) {
 	return out, nil
 }
 
-// OutFileName returns the intermediate output basename go test writes for this profile (before move to bench/).
+// OutFileName returns the intermediate output basename go test writes for this profile (before move to .prof/).
 func (c *Catalog) OutFileName(profileID string) (string, bool) {
 	if c == nil {
 		return "", false

--- a/internal/intent/kind.go
+++ b/internal/intent/kind.go
@@ -8,7 +8,7 @@ import (
 type Kind string
 
 const (
-	// KindCollect runs benchmarks and collects profiles under bench/<tag>/.
+	// KindCollect runs benchmarks and collects profiles under .prof/<tag>/.
 	KindCollect Kind = "collect"
 	// KindConfigCreate writes the default prof.json beside go.mod.
 	KindConfigCreate Kind = "config_create"

--- a/internal/tui/hub.go
+++ b/internal/tui/hub.go
@@ -7,6 +7,8 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+
+	"github.com/AlexsanderHamir/prof/internal/workspace"
 )
 
 // MainAction is the user's choice from the hub; the CLI dispatches to engines.
@@ -139,7 +141,7 @@ func (m *hubModel) View() string {
 
 	if m.showHelp {
 		b.WriteString(helpStyle.Render(
-			"Run Benchmarks & Collect Profiles: run existing benchmarks and store profiles under bench/<tag>/.\n" +
+			fmt.Sprintf("Run Benchmarks & Collect Profiles: run existing benchmarks and store profiles under %s/<tag>/.\n", workspace.MainDirOutput) +
 				"Create Configuration File: writes prof.json and prof.json.example beside go.mod.\n" +
 				"Press ? again to hide this help.",
 		))

--- a/internal/workspace/const.go
+++ b/internal/workspace/const.go
@@ -1,9 +1,9 @@
 package workspace
 
-// Path and permission constants for bench/<tag>/ layout.
+// Path and permission constants for .prof/<tag>/ layout.
 // Domains follow domain/<benchmark>/artifact (profile kind is a segment under source_lines/ and call_graphs/).
 const (
-	MainDirOutput            = "bench"
+	MainDirOutput            = ".prof"
 	ProfilesDir              = "profiles"
 	MeasurementsDir          = "measurements"
 	HotspotsDir              = "hotspots"

--- a/internal/workspace/doc.go
+++ b/internal/workspace/doc.go
@@ -1,4 +1,4 @@
-// Package workspace defines bench/<tag>/ layout paths and tag lifecycle helpers.
+// Package workspace defines .prof/<tag>/ layout paths and tag lifecycle helpers.
 //
 // Artifact domains under each tag describe the data they hold (domain/benchmark/artifact):
 //

--- a/internal/workspace/layout.go
+++ b/internal/workspace/layout.go
@@ -6,13 +6,13 @@ import (
 	"path/filepath"
 )
 
-// TagLayout is the canonical bench/<tag>/ artifact path contract.
+// TagLayout is the canonical .prof/<tag>/ artifact path contract.
 type TagLayout struct {
 	Tag  string
-	Root string // absolute bench/<tag>/
+	Root string // absolute .prof/<tag>/
 }
 
-// NewTagLayout builds layout paths under moduleRoot/bench/tag.
+// NewTagLayout builds layout paths under moduleRoot/.prof/tag.
 func NewTagLayout(moduleRoot, tag string) TagLayout {
 	return TagLayout{
 		Tag:  tag,
@@ -29,7 +29,7 @@ func TagLayoutFromCWD(tag string) (TagLayout, error) {
 	return NewTagLayout(root, tag), nil
 }
 
-// TagDirFromCWD returns bench/<tag>/ under the current module root.
+// TagDirFromCWD returns .prof/<tag>/ under the current module root.
 func TagDirFromCWD(tag string) (string, error) {
 	l, err := TagLayoutFromCWD(tag)
 	if err != nil {

--- a/internal/workspace/layout_test.go
+++ b/internal/workspace/layout_test.go
@@ -23,27 +23,27 @@ func TestTagLayout_paths(t *testing.T) {
 		{
 			"profile binary",
 			l.ProfileBinary("BenchmarkFoo", "cpu"),
-			filepath.Join(root, "bench", "v1", "profiles", "BenchmarkFoo", "cpu.out"),
+			filepath.Join(root, workspace.MainDirOutput, "v1", "profiles", "BenchmarkFoo", "cpu.out"),
 		},
 		{
 			"hotspot",
 			l.Hotspot("BenchmarkFoo", "cpu"),
-			filepath.Join(root, "bench", "v1", "hotspots", "BenchmarkFoo", "cpu.txt"),
+			filepath.Join(root, workspace.MainDirOutput, "v1", "hotspots", "BenchmarkFoo", "cpu.txt"),
 		},
 		{
 			"source lines",
 			l.SourceLinesDir("cpu", "BenchmarkFoo"),
-			filepath.Join(root, "bench", "v1", "source_lines", "cpu", "BenchmarkFoo"),
+			filepath.Join(root, workspace.MainDirOutput, "v1", "source_lines", "cpu", "BenchmarkFoo"),
 		},
 		{
 			"measurement",
 			l.Measurement("BenchmarkFoo"),
-			filepath.Join(root, "bench", "v1", "measurements", "BenchmarkFoo", "run.txt"),
+			filepath.Join(root, workspace.MainDirOutput, "v1", "measurements", "BenchmarkFoo", "run.txt"),
 		},
 		{
 			"call graph",
 			l.CallGraph("cpu", "BenchmarkFoo"),
-			filepath.Join(root, "bench", "v1", "call_graphs", "cpu", "BenchmarkFoo", "cpu.png"),
+			filepath.Join(root, workspace.MainDirOutput, "v1", "call_graphs", "cpu", "BenchmarkFoo", "cpu.png"),
 		},
 	}
 	for _, tc := range cases {

--- a/prof_web_doc/docs/cli-reference.md
+++ b/prof_web_doc/docs/cli-reference.md
@@ -19,7 +19,7 @@ Static site output is written to `prof_web_doc/site/` when you run `mkdocs build
 | ------- | ------- |
 | `prof ui` | Full-screen menu: collect profiles, create configuration, documentation link. |
 | `prof tui` | Terminal collect flow (multi-select benchmarks and profiles). |
-| `prof auto` | Run `go test` benchmarks and collect listed profiles into `bench/<tag>/`. |
+| `prof auto` | Run `go test` benchmarks and collect listed profiles into `.prof/<tag>/`. |
 | `prof manual` | Ingest existing profile files into the same layout style (no `go test`). |
 | `prof config init` | Create minimal `prof.json` and commented `prof.json.example` next to `go.mod`. |
 | `prof config validate` | Load and validate `prof.json`; exit non-zero on error. |
@@ -43,7 +43,7 @@ These IDs are the ones `go test` integration supports (comma-separated for `--pr
 | ---- | ---- | --------- | ------- | ----------- |
 | `--benchmarks` | strings (repeatable, comma-separated) | Yes | n/a | Benchmark names to run (for example `BenchmarkGenPool`). |
 | `--profiles` | strings | Yes | n/a | Profile IDs, comma-separated (for example `cpu,memory,mutex,block`). |
-| `--tag` | string | Yes | n/a | Tag directory name under `bench/`. |
+| `--tag` | string | Yes | n/a | Tag directory name under `.prof/`. |
 | `--count` | int | Yes | n/a | Number of benchmark iterations or runs `go test` should perform (must be positive). |
 
 ## `prof manual`
@@ -52,7 +52,7 @@ Positional arguments are one or more profile file paths to ingest.
 
 | Flag | Type | Required | Default | Description |
 | ---- | ---- | --------- | ------- | ----------- |
-| `--tag` | string | Yes | n/a | Tag directory name under `bench/`. |
+| `--tag` | string | Yes | n/a | Tag directory name under `.prof/`. |
 
 ## Exit codes
 

--- a/prof_web_doc/docs/collect.md
+++ b/prof_web_doc/docs/collect.md
@@ -1,6 +1,6 @@
 # Collect profiling data
 
-This guide explains how to capture benchmark profiles into `bench/<tag>/` using `prof auto` (runs `go test`) or `prof manual` (ingests existing profile files), so you can compare runs or open them in `pprof` later.
+This guide explains how to capture benchmark profiles into `.prof/<tag>/` using `prof auto` (runs `go test`) or `prof manual` (ingests existing profile files), so you can compare runs or open them in `pprof` later.
 
 ## Before you begin
 
@@ -10,7 +10,7 @@ This guide explains how to capture benchmark profiles into `bench/<tag>/` using 
 
 ## What is a profile run?
 
-A run is one labeled experiment: benchmarks executed (or files ingested), profiles of selected types written under `bench/<tag>/`, plus text listings and optional per-function extracts.
+A run is one labeled experiment: benchmarks executed (or files ingested), profiles of selected types written under `.prof/<tag>/`, plus text listings and optional per-function extracts.
 
 ## Commands
 
@@ -35,12 +35,12 @@ prof auto --benchmarks "BenchmarkGenPool" --profiles "cpu,memory,mutex,block" --
 | ---- | ---- | --------- | ------- | ----------- |
 | `--benchmarks` | strings | Yes | n/a | Benchmark names to run. |
 | `--profiles` | strings | Yes | n/a | Comma-separated profile IDs: `cpu`, `memory`, `mutex`, `block`. |
-| `--tag` | string | Yes | n/a | Output directory `bench/<tag>/`. |
+| `--tag` | string | Yes | n/a | Output directory `.prof/<tag>/`. |
 | `--count` | int | Yes | n/a | Number of runs; must be positive. |
 
 ### What collection stores
 
-Each run writes a single tag directory, `bench/<tag>/`, under your [module root](index.md#terminology) (same cwd rules as [Working directory and paths](workspace.md)). That folder is the durable record of one experiment: which benchmarks ran, how many iterations you requested, and which profile types you enabled.
+Each run writes a single tag directory, `.prof/<tag>/`, under your [module root](index.md#terminology) (same cwd rules as [Working directory and paths](workspace.md)). That folder is the durable record of one experiment: which benchmarks ran, how many iterations you requested, and which profile types you enabled.
 
 #### What is being collected
 
@@ -52,10 +52,10 @@ Each run writes a single tag directory, `bench/<tag>/`, under your [module root]
 #### How that helps
 
 - Open profiles in `pprof`: binary and text files under each tag share predictable paths.
-- Share context: zip `bench/<tag>/` or attach key `hotspots/` or `measurements/` files to an issue or PR so others see the same profile view you did.
+- Share context: zip `.prof/<tag>/` or attach key `hotspots/` or `measurements/` files to an issue or PR so others see the same profile view you did.
 - Re-open in pprof: point `go tool pprof` at `profiles/<BenchmarkName>/<profile>.out` for ad-hoc queries on the stored binary.
 
-### Artifact layout under `bench/<tag>/` { #artifact-layout-under-benchtag }
+### Artifact layout under `.prof/<tag>/` { #artifact-layout-under-benchtag }
 
 | Location | What you get | Typical use |
 | -------- | ------------- | ----------- |
@@ -78,13 +78,13 @@ prof manual --tag "external-profiles" cpu.prof memory.prof
 
 | Flag | Type | Required | Default | Description |
 | ---- | ---- | --------- | ------- | ----------- |
-| `--tag` | string | Yes | n/a | Output directory `bench/<tag>/`. |
+| `--tag` | string | Yes | n/a | Output directory `.prof/<tag>/`. |
 
 Per-file collection filters use `collection.manual_profiles` in `prof.json`. Keys are profile file stems (e.g. `BenchmarkFoo_cpu` for `BenchmarkFoo_cpu.out`). See [Configure — manual profile overrides](configure.md#collection-manual-profiles).
 
 ## Testing / verify
 
-After `prof auto`, you should see `bench/<tag>/profiles/<BenchmarkName>/` containing `<profile>.out` for each profile you requested, `measurements/<BenchmarkName>/run.txt`, and matching files under `hotspots/<BenchmarkName>/`.
+After `prof auto`, you should see `.prof/<tag>/profiles/<BenchmarkName>/` containing `<profile>.out` for each profile you requested, `measurements/<BenchmarkName>/run.txt`, and matching files under `hotspots/<BenchmarkName>/`.
 
 If `go test` fails, Prof exits non-zero. Fix the test failure first. For PNG or Graphviz issues, see [Troubleshooting](troubleshooting.md#graphviz-png-errors).
 

--- a/prof_web_doc/docs/configure.md
+++ b/prof_web_doc/docs/configure.md
@@ -38,7 +38,7 @@ Copy sections from `prof.json.example` into `prof.json` when you want collection
 
 ## Benchmark discovery
 
-`prof auto` and `prof ui` discover benchmarks by scanning `*_test.go` files under your module root. Directories named `tests/`, `bench/`, and `vendor/`, plus nested directories that contain their own `go.mod` (separate Go modules), are skipped so fixtures and QA sandboxes under `tests/` do not appear in your benchmark list.
+`prof auto` and `prof ui` discover benchmarks by scanning `*_test.go` files under your module root. Directories named `tests/`, `.prof/`, `bench/` (legacy output), and `vendor/`, plus nested directories that contain their own `go.mod` (separate Go modules), are skipped so fixtures and QA sandboxes under `tests/` do not appear in your benchmark list.
 
 ## Full shape (version 1)
 
@@ -68,7 +68,7 @@ When you copy optional sections from `prof.json.example`, a typical project file
 
 ## Collection { #collection }
 
-Controls per-function text extracts after [Collect profiling data](collect.md). Output lands under `bench/<tag>/<profile>_functions/<BenchmarkName>/` when filters match.
+Controls per-function text extracts after [Collect profiling data](collect.md). Output lands under `.prof/<tag>/<profile>_functions/<BenchmarkName>/` when filters match.
 
 | Section | Key meaning |
 | ------- | ----------- |

--- a/prof_web_doc/docs/index.md
+++ b/prof_web_doc/docs/index.md
@@ -1,6 +1,6 @@
 # Prof
 
-Prof is a command-line tool for Go that runs benchmarks with `go test`, captures CPU, memory, mutex, and block profiles, and stores everything under a predictable `bench/<tag>/` tree for analysis with `pprof` and your own tooling.
+Prof is a command-line tool for Go that runs benchmarks with `go test`, captures CPU, memory, mutex, and block profiles, and stores everything under a predictable `.prof/<tag>/` tree for analysis with `pprof` and your own tooling.
 
 Use it when you want comparable profiles across experiments and a stable on-disk layout without memorizing `go test` and `pprof` flags.
 
@@ -22,20 +22,20 @@ Use it when you want comparable profiles across experiments and a stable on-disk
 ```mermaid
 flowchart LR
   collect[Collect_prof_auto_or_ui]
-  bench["bench/tag_layout"]
+  bench[".prof/tag_layout"]
   analyze[pprof_or_your_tools]
   collect --> bench
   bench --> analyze
 ```
 
-You label each run with a tag. Prof writes `bench/<tag>/` with binary profiles, text summaries, and optional per-function extracts.
+You label each run with a tag. Prof writes `.prof/<tag>/` with binary profiles, text summaries, and optional per-function extracts.
 
 ## Terminology
 
 | Term | Meaning |
 | ---- | ------- |
 | Module root | Directory containing your `go.mod`; run Prof from here, same as for `go test`. |
-| Tag | Label for one run; artifacts live in `bench/<tag>/`. |
+| Tag | Label for one run; artifacts live in `.prof/<tag>/`. |
 | Profile type | One of `cpu`, `memory`, `mutex`, `block`. |
 
 ## Source

--- a/prof_web_doc/docs/quickstart.md
+++ b/prof_web_doc/docs/quickstart.md
@@ -11,7 +11,7 @@ This guide gets you from an installed `prof` binary to a tagged collect in about
 
 ## What is a tag?
 
-A tag is a short label for one profiling run. Prof writes all artifacts for that run under `bench/<tag>/`.
+A tag is a short label for one profiling run. Prof writes all artifacts for that run under `.prof/<tag>/`.
 
 ## Path A: menus (default)
 
@@ -25,7 +25,7 @@ prof ui
 
 In the menu, choose Collect Profiles, pick your benchmarks and profile types, and enter a tag such as `baseline`.
 
-Verify: you should see `bench/baseline/` with `profiles/`, `measurements/`, and `hotspots/` populated.
+Verify: you should see `.prof/baseline/` with `profiles/`, `measurements/`, and `hotspots/` populated.
 
 If the UI does not start, your environment may not expose a TTY. Use Path B or see [Troubleshooting](troubleshooting.md#prof-ui-or-prof-tui-fails-in-ci-or-ides).
 
@@ -37,7 +37,7 @@ prof auto --benchmarks "BenchmarkExample" --profiles "cpu,memory,mutex,block" --
 
 Verify:
 
-- On disk: `bench/baseline/` contains `profiles/BenchmarkExample/`, `measurements/BenchmarkExample/`, and `hotspots/BenchmarkExample/`.
+- On disk: `.prof/baseline/` contains `profiles/BenchmarkExample/`, `measurements/BenchmarkExample/`, and `hotspots/BenchmarkExample/`.
 
 ## If something fails
 

--- a/prof_web_doc/docs/troubleshooting.md
+++ b/prof_web_doc/docs/troubleshooting.md
@@ -10,11 +10,11 @@ Menus never appear, or you see an error about stdin or stdout not being a TTY.
 
 Use non-interactive commands instead: `prof auto` and `prof manual`. See [Quickstart](quickstart.md) Path B and [CLI reference](cli-reference.md).
 
-### Wrong directory or no bench folder {#wrong-directory-or-no-bench-folder}
+### Wrong directory or no bench folder {#wrong-directory-or-no-prof-folder}
 
 Collect succeeds elsewhere, or `bench/` appears in the wrong repo.
 
-Prof writes `bench/` under the current working directory, which must be your module root (where `go.mod` lives).
+Prof writes `.prof/` under the current working directory, which must be your module root (where `go.mod` lives).
 
 `cd` to the same directory you use for `go test`, then run Prof again. See [Working directory and paths](workspace.md).
 

--- a/prof_web_doc/docs/tui.md
+++ b/prof_web_doc/docs/tui.md
@@ -1,6 +1,6 @@
 # Interactive UI and TUI
 
-This guide covers `prof ui` (full-screen menus) and `prof tui` (terminal collect). They call the same engines as `prof auto`; artifacts land under `bench/<tag>/`.
+This guide covers `prof ui` (full-screen menus) and `prof tui` (terminal collect). They call the same engines as `prof auto`; artifacts land under `.prof/<tag>/`.
 
 ## Before you begin
 
@@ -35,7 +35,7 @@ Navigation: arrow keys; Space toggles in multi-select; type to filter long lists
 
 ## Testing / verify
 
-After finishing `prof tui` or the collect path in `prof ui`, confirm `bench/<tag>/` exists with `profiles/`, `measurements/`, and `hotspots/` populated.
+After finishing `prof tui` or the collect path in `prof ui`, confirm `.prof/<tag>/` exists with `profiles/`, `measurements/`, and `hotspots/` populated.
 
 ## Next steps
 

--- a/prof_web_doc/docs/workspace.md
+++ b/prof_web_doc/docs/workspace.md
@@ -1,6 +1,6 @@
 # Working directory and paths
 
-This page explains where Prof reads your module, where it writes `bench/`, and how paths are laid out under each tag so `pprof` and your own tooling can find data.
+This page explains where Prof reads your module, where it writes `.prof/`, and how paths are laid out under each tag so `pprof` and your own tooling can find data.
 
 ## Before you begin
 
@@ -9,25 +9,25 @@ This page explains where Prof reads your module, where it writes `bench/`, and h
 
 ## What Prof uses from cwd
 
-Prof uses your current working directory to find the Go module and to write `bench/`. Run from the same place you run `go test` for that module (usually the [module root](index.md#terminology)).
+Prof uses your current working directory to find the Go module and to write `.prof/`. Run from the same place you run `go test` for that module (usually the [module root](index.md#terminology)).
 
 - Benchmark discovery is relative to cwd (same rules as `go test`).
-- Output goes to `bench/<tag>/` under cwd ([terminology](index.md#terminology)).
+- Output goes to `.prof/<tag>/` under cwd ([terminology](index.md#terminology)).
 - `prof config init` writes minimal `prof.json` and commented `prof.json.example` next to `go.mod` at the module root. Keep cwd aligned with that root when you expect those files to be found.
 
-## Directory layout under `bench/<tag>/`
+## Directory layout under `.prof/<tag>/`
 
-Using Prof creates a `bench/` tree next to your module, one folder per run (tag). Domains describe the data they hold (`domain/<BenchmarkName>/artifact`).
+Using Prof creates a `.prof/` tree next to your module, one folder per run (tag). Domains describe the data they hold (`domain/<BenchmarkName>/artifact`).
 
 | Path | What it is |
 | ---- | ---------- |
-| `bench/<tag>/` | One labeled run: profiles, measurements, hotspots, and optional extracts for that tag. |
-| `bench/<tag>/profiles/<BenchmarkName>/` | Raw pprof profile binaries (`.out`); durable source for `go tool pprof`. |
-| `bench/<tag>/measurements/<BenchmarkName>/` | `go test` benchmark run stats (`run.txt`: ns/op, allocs). |
-| `bench/<tag>/hotspots/<BenchmarkName>/` | Function-ranked stack summaries per profile (`cpu.txt`, `memory.txt`). |
-| `bench/<tag>/source_lines/<profile>/<BenchmarkName>/` | Per-function `pprof -list` extracts when configured. |
-| `bench/<tag>/call_graphs/<profile>/<BenchmarkName>/` | Optional Graphviz PNG call graphs when installed. |
-| `bench/<tag>/notes.txt` | Short tag-level note (placeholder until you edit it). |
+| `.prof/<tag>/` | One labeled run: profiles, measurements, hotspots, and optional extracts for that tag. |
+| `.prof/<tag>/profiles/<BenchmarkName>/` | Raw pprof profile binaries (`.out`); durable source for `go tool pprof`. |
+| `.prof/<tag>/measurements/<BenchmarkName>/` | `go test` benchmark run stats (`run.txt`: ns/op, allocs). |
+| `.prof/<tag>/hotspots/<BenchmarkName>/` | Function-ranked stack summaries per profile (`cpu.txt`, `memory.txt`). |
+| `.prof/<tag>/source_lines/<profile>/<BenchmarkName>/` | Per-function `pprof -list` extracts when configured. |
+| `.prof/<tag>/call_graphs/<profile>/<BenchmarkName>/` | Optional Graphviz PNG call graphs when installed. |
+| `.prof/<tag>/notes.txt` | Short tag-level note (placeholder until you edit it). |
 | `prof.json` | Active config next to `go.mod` after `prof config init` or **Manage configuration** in `prof ui`. |
 | `prof.json.example` | Commented reference (not loaded); copy optional sections into `prof.json`. See [Configure — generated files](configure.md#generated-files). |
 
@@ -42,9 +42,9 @@ Both files live beside `go.mod` at the module root:
 
 ## Testing / verify
 
-From the module root, after a successful collect, you should see a new directory `bench/<your-tag>/` with at least `profiles/<BenchmarkName>/`, `measurements/<BenchmarkName>/`, and `hotspots/<BenchmarkName>/` populated for the profiles you enabled.
+From the module root, after a successful collect, you should see a new directory `.prof/<your-tag>/` with at least `profiles/<BenchmarkName>/`, `measurements/<BenchmarkName>/`, and `hotspots/<BenchmarkName>/` populated for the profiles you enabled.
 
-If `bench/` never appears, see [Troubleshooting](troubleshooting.md#wrong-directory-or-no-bench-folder).
+If `.prof/` never appears, see [Troubleshooting](troubleshooting.md#wrong-directory-or-no-prof-folder).
 
 ## Next steps
 

--- a/prof_web_doc/mkdocs.yml
+++ b/prof_web_doc/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Prof documentation
-site_description: Go benchmark profiling with prof ui menus and bench output under bench/.
+site_description: Go benchmark profiling with prof ui menus and bench output under .prof/.
 site_url: https://alexsanderhamir.github.io/prof/
 
 repo_url: https://github.com/AlexsanderHamir/prof

--- a/tests/blackbox_test.go
+++ b/tests/blackbox_test.go
@@ -22,7 +22,7 @@ func skipSlowIntegration(t *testing.T) {
 }
 
 // TestAutoEndToEnd validates the full `prof auto` pipeline once: build the
-// prof binary, run `go test -bench`, collect profiles, write the bench/<tag>/
+// prof binary, run `go test -bench`, collect profiles, write the .prof/<tag>/
 // layout. Runs at smokeCount because we're asserting wiring + layout, not
 // CPU sampling stability — filter behavior is covered by TestFunctionFilter
 // against deterministic committed fixtures.

--- a/tests/qa-ui-manual/.gitignore
+++ b/tests/qa-ui-manual/.gitignore
@@ -1,4 +1,5 @@
 # QA sandbox runtime artifacts — keep personas/ and source, ignore generated output
+/.prof/
 /bench/
 /prof.exe
 /prof.json

--- a/tests/shared_env.go
+++ b/tests/shared_env.go
@@ -13,7 +13,7 @@ import (
 // TestProfileValidation, TestCommandValidation). The module is materialized
 // at most once per `go test` process and torn down by TestMain on exit.
 //
-// `prof auto` always cleans bench/<tag>/ before each run (see internal/workspace),
+// `prof auto` always cleans .prof/<tag>/ before each run (see internal/workspace),
 // so reusing the same tag across scenarios is safe — leftover artifacts from a
 // previous test never leak into the next test's assertions.
 var (


### PR DESCRIPTION
## Summary
- Rename the canonical output root from `bench/` to `.prof/` via `workspace.MainDirOutput`, giving prof a dedicated, tool-specific artifact directory at the module root.
- Derive CLI/TUI prompts and cobra help from `workspace.MainDirOutput` so user-facing copy stays aligned with the layout constant.
- Update gitignore, contributor docs, and user guides; keep skipping legacy `bench/` during benchmark discovery.

## Commits
1. `feat(workspace): rename collect output root from bench to .prof`
2. `feat(cli): derive output path labels from workspace.MainDirOutput`
3. `chore: update collect package comments for .prof layout`
4. `chore: ignore .prof output and update lint copy`
5. `docs: document .prof output directory`

## Test plan
- [x] `go test ./internal/workspace/... ./cli/...`
- [ ] `go test ./...`
- [ ] `golangci-lint run`
- [ ] Manual: `go run ./cmd/prof ui` → collect with tag `baseline` → confirm `.prof/baseline/` is created (not `bench/baseline/`)