### PR TITLE
feat: emit per-benchmark map.json under data_mapping/

### DIFF
--- a/CODEBASE_DESIGN.md
+++ b/CODEBASE_DESIGN.md
@@ -118,6 +118,7 @@ All paths come from [`workspace.TagLayout`](internal/workspace/layout.go):
     ├── measurements/<BenchmarkName>/run.txt
     ├── hotspots/<BenchmarkName>/<profile>.txt
     ├── source_lines/<profile>/<BenchmarkName>/<function>.txt
+    ├── data_mapping/<BenchmarkName>/map.json
     └── call_graphs/<profile>/<BenchmarkName>/<profile>.png
 ```
 

--- a/docs/collect-request-flow.md
+++ b/docs/collect-request-flow.md
@@ -189,6 +189,10 @@ Resolved function filters for each benchmark come from `config.ResolveCollection
 
 **Concurrency:** profile kinds and per-function `-list` subprocesses run with a bounded worker pool (`min(jobCount, GOMAXPROCS, 8)`). Artifacts, filters, and argv are unchanged; see [source-lines-parallelism.md](../design/source-lines-parallelism.md).
 
+#### Step 4 — Benchmark data map
+
+After step 3, [`emitBenchmarkMap`](../engine/collect/datamap_emit.go) writes `data_mapping/<Benchmark>/map.json` — a JSON index of measurements, profiles, hotspots, call trees, and source-line function inventory for LLM/agent navigation. Paths in the file are relative to `.prof/<tag>/`. Map emit failures warn and continue; they do not fail the collect run. See [benchmark-data-map.md](../design/benchmark-data-map.md).
+
 When all benchmarks finish, prof logs collection success and returns.
 
 ## Output layout (example)
@@ -214,6 +218,8 @@ All paths come from [`workspace.TagLayout`](../internal/workspace/layout.go). Fo
     │   └── <function>.txt
     └── source_lines/memory/BenchmarkMatrixMultiplication/
         └── <function>.txt
+    └── data_mapping/BenchmarkMatrixMultiplication/
+        └── map.json
 ```
 
 PNG files, when generated, live under `call_graphs/<profile>/<benchmark>/`.
@@ -231,6 +237,7 @@ PNG files, when generated, live under `call_graphs/<profile>/<benchmark>/`.
 | Artifact paths or tag lifecycle | [`internal/workspace/layout.go`](../internal/workspace/layout.go), [`engine/collect/layout.go`](../engine/collect/layout.go) |
 | Missing profile / PNG handling | [`engine/collect/profiles.go`](../engine/collect/profiles.go) |
 | Per-function file list and filters | [`parser/`](../parser/), [`internal/config/filter.go`](../internal/config/filter.go) |
+| Benchmark map.json index | [`internal/datamap/`](../internal/datamap/), [`engine/collect/datamap_emit.go`](../engine/collect/datamap_emit.go) |
 
 ## Layering
 

--- a/docs/design/benchmark-data-map.md
+++ b/docs/design/benchmark-data-map.md
@@ -1,0 +1,130 @@
+# Benchmark data map (map.json)
+
+## Context
+
+After collect, `.prof/<tag>/` holds hotspots, call trees, source lines, measurements, and raw profiles across **asymmetric paths**. LLM agents and tooling must discover what exists, what each artifact means, and which functions were extracted — without scanning the tree or reading hundreds of lines of hotspot text first.
+
+## Decision
+
+Emit one **machine-readable index** per benchmark at the end of each benchmark pipeline:
+
+```text
+.prof/<tag>/data_mapping/<BenchmarkName>/map.json
+```
+
+Paths inside JSON are **relative to `.prof/<tag>/`**. The map is built from data **already parsed during collect** (no extra `pprof` subprocesses). Map emit failures **warn and continue** — they do not fail a successful collect run.
+
+Schema types and builder live in [`internal/datamap`](../../internal/datamap/). Layout paths: [`TagLayout.DataMapping`](../../internal/workspace/layout.go).
+
+## Purpose enums
+
+| Value | Section | Meaning |
+| --- | --- | --- |
+| `go_test_benchmem_results` | measurements | `go test -benchmem` transcript |
+| `raw_pprof_binary` | profiles | Source `.out` binary |
+| `flat_and_cumulative_ranking` | hotspots | `pprof -top` text |
+| `caller_callee_context` | call_trees | `pprof -tree` text |
+| `line_level_source_extract` | source_lines | Per-function `pprof -list` |
+| `visual_call_graph` | call_graphs | Optional PNG |
+
+## Recommended reading flow
+
+1. **measurements** — confirm benchmark ran; headline ns/op and allocs
+2. **hotspots** — find top symbols (`top_symbols` in map)
+3. **call_trees** — understand call path (`hot_path_summary`)
+4. **source_lines** — line-level detail for chosen symbols
+5. **profiles** — raw binary only if deeper pprof queries needed
+
+## Example (truncated)
+
+```json
+{
+  "schema_version": 1,
+  "tag": "baseline",
+  "benchmark": "BenchmarkDataGeneration",
+  "recommended_flow": ["measurements", "hotspots", "call_trees", "source_lines", "profiles"],
+  "measurements": {
+    "path": "measurements/BenchmarkDataGeneration/run.txt",
+    "purpose": "go_test_benchmem_results",
+    "summary": { "ns_per_op_median": 64894, "bytes_per_op": 88056, "allocs_per_op": 1750 }
+  },
+  "profiles": {
+    "cpu": {
+      "path": "profiles/BenchmarkDataGeneration/cpu.out",
+      "purpose": "raw_pprof_binary"
+    }
+  },
+  "hotspots": {
+    "cpu": {
+      "path": "hotspots/BenchmarkDataGeneration/cpu.txt",
+      "purpose": "flat_and_cumulative_ranking",
+      "producer": "go tool pprof -top",
+      "top_symbols": [
+        {
+          "rank": 1,
+          "symbol": "github.com/example/benchmarks/utils.(*DataGenerator).GenerateStrings",
+          "flat_pct": 1.28,
+          "cum_pct": 70.53
+        }
+      ]
+    }
+  },
+  "call_trees": {
+    "cpu": {
+      "path": "call_trees/BenchmarkDataGeneration/cpu.txt",
+      "purpose": "caller_callee_context",
+      "producer": "go tool pprof -tree"
+    }
+  },
+  "source_lines": {
+    "cpu": {
+      "dir": "source_lines/cpu/BenchmarkDataGeneration",
+      "path_pattern": "source_lines/{profile}/{benchmark}/{output_stem}.txt",
+      "purpose": "line_level_source_extract",
+      "functions": {
+        "GenerateStrings": {
+          "path": "source_lines/cpu/BenchmarkDataGeneration/GenerateStrings.txt",
+          "full_symbol": "github.com/example/benchmarks/utils.(*DataGenerator).GenerateStrings",
+          "status": "ok"
+        }
+      }
+    }
+  },
+  "provenance": {
+    "tag": "baseline",
+    "collection_mode": "auto",
+    "profiles_requested": ["cpu", "memory"]
+  },
+  "status": {
+    "benchmark_run": "ok",
+    "profiles": { "cpu": "ok" },
+    "source_lines": { "cpu": { "collected": 156, "skipped": 0, "failed": 0 } }
+  }
+}
+```
+
+## Invariants
+
+- Same `FunctionListEntry` set as source_lines on disk (from `prof.json` filters).
+- Relative paths only — no absolute machine paths in JSON.
+- Auto and manual collect produce the same schema shape.
+- Tag-level manifest is **out of scope** for v1.
+
+## Consequences
+
+**Positive:** Agents load one JSON file to triage before opening large text artifacts.
+
+**Neutral:** map.json grows with function count; acceptable for v1.
+
+## Out of scope (v2)
+
+- Tag-level `manifest.json`
+- Cross-tag comparison hooks
+- `triage_hint` synthesis
+- Hot line parsing from `-list` output
+- Post-hoc disk scanning
+
+## See also
+
+- [Collect request flow — Step 4](../collect-request-flow.md#step-4--benchmark-data-map)
+- [Parallel source_lines collection](./source-lines-parallelism.md)

--- a/engine/collect/artifacts_pprof.go
+++ b/engine/collect/artifacts_pprof.go
@@ -85,32 +85,42 @@ func writeFunctionListPprof(runner tooling.Runner, shortStem, fullSymbol, binary
 	return lastErr
 }
 
-func getFunctionsOutput(runner tooling.Runner, entries []parser.FunctionListEntry, binaryPath, basePath string, session *termui.Session) error {
+// ListResult summarizes per-function pprof -list collection for one profile.
+type ListResult struct {
+	Collected   int
+	Skipped     int
+	FailedStems map[string]struct{}
+}
+
+func getFunctionsOutput(runner tooling.Runner, entries []parser.FunctionListEntry, binaryPath, basePath string, session *termui.Session) ListResult {
 	const maxPerFunctionWarnings = 3
 
+	result := ListResult{FailedStems: make(map[string]struct{})}
 	errs := parallelFor(len(entries), sourceLinesWorkers(len(entries)), func(i int) error {
 		e := entries[i]
 		out := filepath.Join(basePath, e.OutputStem+"."+workspace.TextExtension)
 		return writeFunctionListPprof(runner, e.OutputStem, e.FullSymbol, binaryPath, out)
 	})
 
-	var skipped int
 	for i, err := range errs {
 		if err == nil {
+			result.Collected++
 			continue
 		}
-		skipped++
-		if session != nil && session.Interactive() && skipped <= maxPerFunctionWarnings {
+		result.Skipped++
+		result.FailedStems[entries[i].OutputStem] = struct{}{}
+		if session != nil && session.Interactive() && result.Skipped <= maxPerFunctionWarnings {
 			session.Warn(fmt.Sprintf("skipping per-function pprof list for %s: %v", entries[i].OutputStem, err))
 		}
 	}
-	if skipped > maxPerFunctionWarnings && session != nil && session.Interactive() {
-		session.Warn(fmt.Sprintf("… and %d more functions skipped", skipped-maxPerFunctionWarnings))
+	if result.Skipped > maxPerFunctionWarnings && session != nil && session.Interactive() {
+		session.Warn(fmt.Sprintf("… and %d more functions skipped", result.Skipped-maxPerFunctionWarnings))
 	}
-	return nil
+	return result
 }
 
 // FunctionsOutput runs pprof -list for each entry (exported for integration tests).
 func FunctionsOutput(runner tooling.Runner, entries []parser.FunctionListEntry, binaryPath, basePath string) error {
-	return getFunctionsOutput(runner, entries, binaryPath, basePath, nil)
+	_ = getFunctionsOutput(runner, entries, binaryPath, basePath, nil)
+	return nil
 }

--- a/engine/collect/artifacts_test.go
+++ b/engine/collect/artifacts_test.go
@@ -93,8 +93,9 @@ func TestGetFunctionsOutput_fakeRunner(t *testing.T) {
 		Out: [][]byte{[]byte("list output for " + pick.OutputStem)},
 	}
 	dir := t.TempDir()
-	if outErr := getFunctionsOutput(runner, []parser.FunctionListEntry{pick}, cpuPath, dir, nil); outErr != nil {
-		t.Fatal(outErr)
+	result := getFunctionsOutput(runner, []parser.FunctionListEntry{pick}, cpuPath, dir, nil)
+	if result.Collected != 1 || result.Skipped != 0 {
+		t.Fatalf("result=%+v", result)
 	}
 	outFile := filepath.Join(dir, pick.OutputStem+"."+workspace.TextExtension)
 	if _, statErr := os.Stat(outFile); statErr != nil {
@@ -121,8 +122,9 @@ func TestGetFunctionsOutput_parallelFakeRunner(t *testing.T) {
 	}
 	runner := &tooling.FakeRunner{Out: outs}
 	dir := t.TempDir()
-	if outErr := getFunctionsOutput(runner, entries, cpuPath, dir, nil); outErr != nil {
-		t.Fatal(outErr)
+	result := getFunctionsOutput(runner, entries, cpuPath, dir, nil)
+	if result.Collected != len(entries) {
+		t.Fatalf("collected=%d want=%d", result.Collected, len(entries))
 	}
 	if len(runner.Runs) != len(entries) {
 		t.Fatalf("expected %d pprof runs, got %d", len(entries), len(runner.Runs))

--- a/engine/collect/datamap_emit.go
+++ b/engine/collect/datamap_emit.go
@@ -1,0 +1,109 @@
+package collect
+
+import (
+	"bufio"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/AlexsanderHamir/prof/internal/config"
+	"github.com/AlexsanderHamir/prof/internal/datamap"
+	"github.com/AlexsanderHamir/prof/internal/termui"
+	"github.com/AlexsanderHamir/prof/internal/workspace"
+)
+
+type emitMapParams struct {
+	Tag              string
+	Benchmark        string
+	Profiles         []string
+	Filter           config.FunctionFilter
+	BenchCount       int
+	CollectionMode   string
+	PerProfile       []datamap.ProfileSnapshot
+	IncludeMeasuring bool
+}
+
+func emitBenchmarkMap(session *termui.Session, layout workspace.TagLayout, params emitMapParams) {
+	pkg := ""
+	if params.CollectionMode == datamapCollectionAuto {
+		pkg = benchmarkImportPath(params.Benchmark)
+	}
+
+	m, err := datamap.Build(datamap.BuildInput{
+		Layout:           layout,
+		Tag:              params.Tag,
+		Benchmark:        params.Benchmark,
+		Package:          pkg,
+		CollectionMode:   params.CollectionMode,
+		Profiles:         params.Profiles,
+		Filter:           params.Filter,
+		BenchCount:       params.BenchCount,
+		PerProfile:       params.PerProfile,
+		IncludeMeasuring: params.IncludeMeasuring,
+	})
+	if err != nil {
+		warnMapEmit(session, fmt.Sprintf("benchmark map build failed for %s: %v", params.Benchmark, err))
+		return
+	}
+	path := layout.DataMapping(params.Benchmark)
+	if writeErr := datamap.WriteJSON(path, m); writeErr != nil {
+		warnMapEmit(session, fmt.Sprintf("benchmark map write failed for %s: %v", params.Benchmark, writeErr))
+		return
+	}
+	slog.Info("Wrote benchmark map", "path", path, "benchmark", params.Benchmark)
+}
+
+func warnMapEmit(session *termui.Session, msg string) {
+	if session != nil && session.Interactive() {
+		session.Warn(msg)
+		return
+	}
+	slog.Warn(msg)
+}
+
+const (
+	datamapCollectionAuto   = "auto"
+	datamapCollectionManual = "manual"
+)
+
+func benchmarkImportPath(benchmarkName string) string {
+	moduleRoot, err := workspace.FindModuleRoot()
+	if err != nil {
+		return ""
+	}
+	pkgDir, err := findBenchmarkPackageDir(moduleRoot, benchmarkName)
+	if err != nil {
+		return ""
+	}
+	modPath := readModulePath(filepath.Join(moduleRoot, "go.mod"))
+	if modPath == "" {
+		return ""
+	}
+	rel, err := filepath.Rel(moduleRoot, pkgDir)
+	if err != nil {
+		return modPath
+	}
+	rel = filepath.ToSlash(rel)
+	if rel == "." {
+		return modPath
+	}
+	return modPath + "/" + rel
+}
+
+func readModulePath(goModPath string) string {
+	f, err := os.Open(goModPath)
+	if err != nil {
+		return ""
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, "module ") {
+			return strings.TrimSpace(strings.TrimPrefix(line, "module "))
+		}
+	}
+	return ""
+}

--- a/engine/collect/datamap_emit_test.go
+++ b/engine/collect/datamap_emit_test.go
@@ -1,0 +1,83 @@
+package collect
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/AlexsanderHamir/prof/engine/tooling"
+	"github.com/AlexsanderHamir/prof/internal/config"
+	"github.com/AlexsanderHamir/prof/internal/datamap"
+	"github.com/AlexsanderHamir/prof/parser"
+)
+
+func TestEmitBenchmarkMap_writesMapJSON(t *testing.T) {
+	const (
+		tag   = "maptest"
+		bench = "BenchmarkFoo"
+	)
+	layout, fixture := setupProcessProfilesEnv(t, tag, []string{"cpu"})
+	copyFixtureToProfile(t, layout, bench, "cpu", fixture)
+
+	runner := &tooling.FakeRunner{
+		Out: [][]byte{
+			[]byte("flat profile text"),
+			[]byte("tree profile text"),
+			[]byte("png-bytes"),
+		},
+	}
+	processed, err := processProfiles(runner, bench, []string{"cpu"}, tag, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(processed) != 1 {
+		t.Fatalf("processed=%v", processed)
+	}
+
+	cpuPath := layout.ProfileBinary(bench, "cpu")
+	filter := config.FunctionFilter{}
+	entries, profileData, err := parser.GetFunctionListEntriesWithProfileData(cpuPath, filter)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("expected function entries from fixture")
+	}
+
+	emitBenchmarkMap(nil, layout, emitMapParams{
+		Tag:            tag,
+		Benchmark:      bench,
+		Profiles:       processed,
+		Filter:         filter,
+		CollectionMode: datamapCollectionAuto,
+		PerProfile: []datamap.ProfileSnapshot{{
+			Profile:              "cpu",
+			ProfileData:          profileData,
+			ListEntries:          entries,
+			SourceLinesCollected: len(entries),
+		}},
+		IncludeMeasuring: false,
+	})
+
+	mapPath := layout.DataMapping(bench)
+	data, err := os.ReadFile(mapPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m datamap.BenchmarkMap
+	if err = json.Unmarshal(data, &m); err != nil {
+		t.Fatal(err)
+	}
+	if m.SchemaVersion != datamap.SchemaVersion {
+		t.Fatalf("schema_version=%d", m.SchemaVersion)
+	}
+	if m.Hotspots["cpu"].Path != "hotspots/BenchmarkFoo/cpu.txt" {
+		t.Fatalf("hotspot path=%q", m.Hotspots["cpu"].Path)
+	}
+	if len(m.SourceLines["cpu"].Functions) == 0 {
+		t.Fatal("expected source_lines functions")
+	}
+	if len(m.Hotspots["cpu"].TopSymbols) == 0 {
+		t.Fatal("expected top_symbols")
+	}
+}

--- a/engine/collect/layout.go
+++ b/engine/collect/layout.go
@@ -13,16 +13,17 @@ func createBenchDirectories(tagDir string, benchmarks []string, quiet bool) erro
 	profilesDir := filepath.Join(tagDir, workspace.ProfilesDir)
 	measurementsDir := filepath.Join(tagDir, workspace.MeasurementsDir)
 	hotspotsDir := filepath.Join(tagDir, workspace.HotspotsDir)
+	dataMappingDir := filepath.Join(tagDir, workspace.DataMappingDir)
 	notesFile := filepath.Join(tagDir, workspace.TagNotesFileName)
 
-	for _, dir := range []string{profilesDir, measurementsDir, hotspotsDir} {
+	for _, dir := range []string{profilesDir, measurementsDir, hotspotsDir, dataMappingDir} {
 		if err := os.Mkdir(dir, workspace.PermDir); err != nil {
 			return fmt.Errorf("failed to create %s directory: %w", filepath.Base(dir), err)
 		}
 	}
 
 	for _, b := range benchmarks {
-		for _, dir := range []string{profilesDir, measurementsDir, hotspotsDir} {
+		for _, dir := range []string{profilesDir, measurementsDir, hotspotsDir, dataMappingDir} {
 			if err := os.Mkdir(filepath.Join(dir, b), workspace.PermDir); err != nil {
 				return fmt.Errorf("failed to create %s subdirectory for %s: %w", filepath.Base(dir), b, err)
 			}

--- a/engine/collect/layout_test.go
+++ b/engine/collect/layout_test.go
@@ -35,10 +35,12 @@ func TestCreateBenchDirectories(t *testing.T) {
 		{"profiles root", filepath.Join(tagDir, workspace.ProfilesDir), true},
 		{"measurements root", filepath.Join(tagDir, workspace.MeasurementsDir), true},
 		{"hotspots root", filepath.Join(tagDir, workspace.HotspotsDir), true},
+		{"data mapping root", filepath.Join(tagDir, workspace.DataMappingDir), true},
 		{"notes", filepath.Join(tagDir, workspace.TagNotesFileName), false},
 		{"profiles bench foo", filepath.Join(tagDir, workspace.ProfilesDir, "BenchmarkFoo"), true},
 		{"measurements bench bar", filepath.Join(tagDir, workspace.MeasurementsDir, "BenchmarkBar"), true},
 		{"hotspots bench bar", filepath.Join(tagDir, workspace.HotspotsDir, "BenchmarkBar"), true},
+		{"data mapping bench foo", filepath.Join(tagDir, workspace.DataMappingDir, "BenchmarkFoo"), true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -109,6 +111,11 @@ func TestSetupDirectories_createsTagLayout(t *testing.T) {
 		{
 			"hotspots bench dir",
 			filepath.Join(layout.Root, workspace.HotspotsDir, "BenchmarkFoo"),
+			true,
+		},
+		{
+			"data mapping bench dir",
+			filepath.Join(layout.Root, workspace.DataMappingDir, "BenchmarkFoo"),
 			true,
 		},
 		{

--- a/engine/collect/manual.go
+++ b/engine/collect/manual.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/AlexsanderHamir/prof/engine/tooling"
 	"github.com/AlexsanderHamir/prof/internal/config"
+	"github.com/AlexsanderHamir/prof/internal/datamap"
 	"github.com/AlexsanderHamir/prof/internal/workspace"
 	"github.com/AlexsanderHamir/prof/parser"
 )
@@ -61,27 +62,44 @@ func processOneManualFile(runner tooling.Runner, fullBinaryPath string, layout w
 	if err := emitProfileArtifacts(runner, binDest, layout, benchName, profile); err != nil {
 		return err
 	}
-	return collectPerFunctionLists(runner, layout, benchName, profile, binDest, filter)
+	snap, err := collectPerFunctionLists(runner, layout, benchName, profile, binDest, filter)
+	if err != nil {
+		return err
+	}
+	emitBenchmarkMap(nil, layout, emitMapParams{
+		Tag:            layout.Tag,
+		Benchmark:      benchName,
+		Profiles:       []string{profile},
+		Filter:         filter,
+		CollectionMode: datamapCollectionManual,
+		PerProfile:     []datamap.ProfileSnapshot{snap},
+	})
+	return nil
 }
 
 func emitProfileArtifacts(runner tooling.Runner, binPath string, layout workspace.TagLayout, benchName, profile string) error {
 	return emitParsedProfileArtifacts(runner, binPath, layout, benchName, profile, nil)
 }
 
-func collectPerFunctionLists(runner tooling.Runner, layout workspace.TagLayout, benchName, profile, binPath string, functionFilter config.FunctionFilter) error {
-	listEntries, err := parser.GetFunctionListEntriesV2(binPath, functionFilter)
+func collectPerFunctionLists(runner tooling.Runner, layout workspace.TagLayout, benchName, profile, binPath string, functionFilter config.FunctionFilter) (datamap.ProfileSnapshot, error) {
+	listEntries, profileData, err := parser.GetFunctionListEntriesWithProfileData(binPath, functionFilter)
 	if err != nil {
-		return fmt.Errorf("extract function names: %w", err)
+		return datamap.ProfileSnapshot{}, fmt.Errorf("extract function names: %w", err)
 	}
 
 	functionDir := layout.SourceLinesDir(profile, benchName)
 	if err = ensureDirExists(functionDir); err != nil {
-		return err
+		return datamap.ProfileSnapshot{}, err
 	}
-	if err = getFunctionsOutput(runner, listEntries, binPath, functionDir, nil); err != nil {
-		return fmt.Errorf("per-function pprof: %w", err)
-	}
-	return nil
+	listResult := getFunctionsOutput(runner, listEntries, binPath, functionDir, nil)
+	return datamap.ProfileSnapshot{
+		Profile:              profile,
+		ProfileData:          profileData,
+		ListEntries:          listEntries,
+		SourceLinesCollected: listResult.Collected,
+		SourceLinesSkipped:   listResult.Skipped,
+		FailedStems:          listResult.FailedStems,
+	}, nil
 }
 
 func copyProfileBinary(src, dest string) error {

--- a/engine/collect/pipeline.go
+++ b/engine/collect/pipeline.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/AlexsanderHamir/prof/engine/tooling"
 	"github.com/AlexsanderHamir/prof/internal/config"
+	"github.com/AlexsanderHamir/prof/internal/datamap"
 	"github.com/AlexsanderHamir/prof/internal/termui"
 	"github.com/AlexsanderHamir/prof/internal/workspace"
 	"github.com/AlexsanderHamir/prof/parser"
@@ -72,7 +73,7 @@ func runBenchAndGetProfiles(runner tooling.Runner, autoArgs *config.AutoArgs, cf
 			BenchmarkConfig: filter,
 		}
 		if err := session.RunWhile(base.WithPhase(termui.PhaseCollectFunctionProfiles), func() error {
-			return collectProfileFunctions(runner, args, session)
+			return collectFunctionsAndEmitMap(runner, args, session, autoArgs, benchmarkName, filter, profilesReady)
 		}); err != nil {
 			return finalizeInteractiveErr(session, fmt.Errorf("failed to collect function profiles for %s: %w", benchmarkName, err))
 		}
@@ -86,13 +87,44 @@ func runBenchAndGetProfiles(runner tooling.Runner, autoArgs *config.AutoArgs, cf
 	return nil
 }
 
-func collectProfileFunctions(runner tooling.Runner, args *config.CollectionArgs, session *termui.Session) error {
-	layout, err := workspace.TagLayoutFromCWD(args.Tag)
+func collectFunctionsAndEmitMap(
+	runner tooling.Runner,
+	args *config.CollectionArgs,
+	session *termui.Session,
+	autoArgs *config.AutoArgs,
+	benchmarkName string,
+	filter config.FunctionFilter,
+	profilesReady []string,
+) error {
+	snapshots, err := collectProfileFunctions(runner, args, session)
 	if err != nil {
 		return err
 	}
+	layout, err := workspace.TagLayoutFromCWD(autoArgs.Tag)
+	if err != nil {
+		return err
+	}
+	emitBenchmarkMap(session, layout, emitMapParams{
+		Tag:              autoArgs.Tag,
+		Benchmark:        benchmarkName,
+		Profiles:         profilesReady,
+		Filter:           filter,
+		BenchCount:       autoArgs.Count,
+		CollectionMode:   datamapCollectionAuto,
+		PerProfile:       snapshots,
+		IncludeMeasuring: true,
+	})
+	return nil
+}
+
+func collectProfileFunctions(runner tooling.Runner, args *config.CollectionArgs, session *termui.Session) ([]datamap.ProfileSnapshot, error) {
+	layout, err := workspace.TagLayoutFromCWD(args.Tag)
+	if err != nil {
+		return nil, err
+	}
 
 	profiles := args.Profiles
+	snapshots := make([]datamap.ProfileSnapshot, len(profiles))
 	errs := parallelFor(len(profiles), sourceLinesWorkers(len(profiles)), func(i int) error {
 		profile := profiles[i]
 		fnDir := layout.SourceLinesDir(profile, args.BenchmarkName)
@@ -101,21 +133,27 @@ func collectProfileFunctions(runner tooling.Runner, args *config.CollectionArgs,
 		}
 
 		binPath := layout.ProfileBinary(args.BenchmarkName, profile)
-		listEntries, listErr := parser.GetFunctionListEntriesV2(binPath, args.BenchmarkConfig)
+		listEntries, profileData, listErr := parser.GetFunctionListEntriesWithProfileData(binPath, args.BenchmarkConfig)
 		if listErr != nil {
 			return fmt.Errorf("failed to extract function names: %w", listErr)
 		}
 
-		if fnErr := getFunctionsOutput(runner, listEntries, binPath, fnDir, session); fnErr != nil {
-			return fmt.Errorf("getAllFunctionsPprofContents failed: %w", fnErr)
+		listResult := getFunctionsOutput(runner, listEntries, binPath, fnDir, session)
+		snapshots[i] = datamap.ProfileSnapshot{
+			Profile:              profile,
+			ProfileData:          profileData,
+			ListEntries:          listEntries,
+			SourceLinesCollected: listResult.Collected,
+			SourceLinesSkipped:   listResult.Skipped,
+			FailedStems:          listResult.FailedStems,
 		}
 		return nil
 	})
 
 	for i, err := range errs {
 		if err != nil {
-			return fmt.Errorf("profile %s: %w", profiles[i], err)
+			return nil, fmt.Errorf("profile %s: %w", profiles[i], err)
 		}
 	}
-	return nil
+	return snapshots, nil
 }

--- a/engine/collect/profiles_test.go
+++ b/engine/collect/profiles_test.go
@@ -11,8 +11,9 @@ import (
 	"github.com/AlexsanderHamir/prof/internal/workspace"
 )
 
-func setupProcessProfilesEnv(t *testing.T, tag, bench string, profiles []string) (workspace.TagLayout, string) {
+func setupProcessProfilesEnv(t *testing.T, tag string, profiles []string) (workspace.TagLayout, string) {
 	t.Helper()
+	const bench = "BenchmarkFoo"
 	fixture := testpaths.MustAsset(t, "fixtures", filterFixtureCPU)
 	modRoot := t.TempDir()
 	writeModuleRoot(t, modRoot)
@@ -48,7 +49,7 @@ func TestProcessProfiles_skipsMissingBinary(t *testing.T) {
 		tag   = "t1"
 		bench = "BenchmarkFoo"
 	)
-	layout, fixture := setupProcessProfilesEnv(t, tag, bench, []string{"cpu", "memory"})
+	layout, fixture := setupProcessProfilesEnv(t, tag, []string{"cpu", "memory"})
 	copyFixtureToProfile(t, layout, bench, "cpu", fixture)
 
 	runner := &tooling.FakeRunner{
@@ -68,7 +69,7 @@ func TestProcessProfiles_failsWhenAllMissing(t *testing.T) {
 		tag   = "t2"
 		bench = "BenchmarkFoo"
 	)
-	_, _ = setupProcessProfilesEnv(t, tag, bench, []string{"cpu", "memory"})
+	_, _ = setupProcessProfilesEnv(t, tag, []string{"cpu", "memory"})
 
 	_, err := processProfiles(&tooling.FakeRunner{}, bench, []string{"cpu", "memory"}, tag, nil)
 	if err == nil {
@@ -81,7 +82,7 @@ func TestProcessProfiles_continuesOnPNGFailure(t *testing.T) {
 		tag   = "t3"
 		bench = "BenchmarkFoo"
 	)
-	layout, fixture := setupProcessProfilesEnv(t, tag, bench, []string{"cpu"})
+	layout, fixture := setupProcessProfilesEnv(t, tag, []string{"cpu"})
 	copyFixtureToProfile(t, layout, bench, "cpu", fixture)
 
 	runner := &tooling.FakeRunner{

--- a/internal/datamap/build.go
+++ b/internal/datamap/build.go
@@ -1,0 +1,331 @@
+package datamap
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/AlexsanderHamir/prof/internal/config"
+	"github.com/AlexsanderHamir/prof/internal/workspace"
+	"github.com/AlexsanderHamir/prof/parser"
+)
+
+const (
+	topSymbolLimit   = 10
+	hotPathLimit     = 5
+	statusOK         = "ok"
+	statusSkipped    = "skipped"
+	collectionAuto   = "auto"
+	collectionManual = "manual"
+)
+
+var (
+	defaultRecommendedFlow = []string{"measurements", "hotspots", "call_trees", "source_lines", "profiles"}
+	defaultReadingGuide    = map[string]string{
+		"measurements": "Go benchmark output (ns/op, B/op, allocs/op). Start here to confirm the run succeeded.",
+		"hotspots":     "pprof -top: functions ranked by flat and cumulative cost.",
+		"call_trees":   "pprof -tree: caller/callee context for top nodes.",
+		"source_lines": "pprof -list extracts per function; use on symbols chosen from hotspots.",
+		"profiles":     "Raw .out binaries; re-query with go tool pprof when text is insufficient.",
+	}
+)
+
+// ProfileSnapshot captures in-memory state for one profile kind at map emit time.
+type ProfileSnapshot struct {
+	Profile              string
+	ProfileData          *parser.ProfileData
+	ListEntries          []parser.FunctionListEntry
+	SourceLinesCollected int
+	SourceLinesSkipped   int
+	FailedStems          map[string]struct{}
+}
+
+// BuildInput is the collect → datamap contract.
+type BuildInput struct {
+	Layout           workspace.TagLayout
+	Tag              string
+	Benchmark        string
+	Package          string
+	CollectionMode   string
+	Profiles         []string
+	Filter           config.FunctionFilter
+	BenchCount       int
+	PerProfile       []ProfileSnapshot
+	IncludeMeasuring bool
+}
+
+// Build assembles a BenchmarkMap from collect inputs without reading profile binaries again.
+func Build(in BuildInput) (BenchmarkMap, error) {
+	if in.Layout.Root == "" {
+		return BenchmarkMap{}, errors.New("datamap: empty layout root")
+	}
+	if in.Benchmark == "" {
+		return BenchmarkMap{}, errors.New("datamap: empty benchmark name")
+	}
+
+	m := BenchmarkMap{
+		SchemaVersion:   SchemaVersion,
+		Tag:             in.Tag,
+		Benchmark:       in.Benchmark,
+		Package:         in.Package,
+		RecommendedFlow: append([]string(nil), defaultRecommendedFlow...),
+		ReadingGuide:    copyReadingGuide(),
+		Profiles:        make(map[string]ProfileRef, len(in.Profiles)),
+		Hotspots:        make(map[string]HotspotSection, len(in.Profiles)),
+		CallTrees:       make(map[string]CallTreeSection, len(in.Profiles)),
+		SourceLines:     make(map[string]SourceLinesSection, len(in.Profiles)),
+		CallGraphs:      make(map[string]CallGraphRef, len(in.Profiles)),
+		Status: Status{
+			Profiles:    make(map[string]string, len(in.Profiles)),
+			Hotspots:    make(map[string]string, len(in.Profiles)),
+			CallTrees:   make(map[string]string, len(in.Profiles)),
+			CallGraphs:  make(map[string]CallGraphStatus, len(in.Profiles)),
+			SourceLines: make(map[string]SourceLinesStatus, len(in.Profiles)),
+		},
+		Provenance: Provenance{
+			Tag:               in.Tag,
+			CollectionMode:    in.CollectionMode,
+			BenchCount:        in.BenchCount,
+			ProfilesRequested: append([]string(nil), in.Profiles...),
+			Filter: FilterSnapshot{
+				IncludePrefixes: append([]string(nil), in.Filter.IncludePrefixes...),
+				IgnoreFunctions: append([]string(nil), in.Filter.IgnoreFunctions...),
+			},
+		},
+	}
+
+	if in.IncludeMeasuring && in.CollectionMode == collectionAuto {
+		if err := m.addMeasurements(in); err != nil {
+			return BenchmarkMap{}, err
+		}
+		m.Status.BenchmarkRun = statusOK
+	}
+
+	snapByProfile := make(map[string]ProfileSnapshot, len(in.PerProfile))
+	for _, snap := range in.PerProfile {
+		snapByProfile[snap.Profile] = snap
+	}
+
+	for _, profile := range in.Profiles {
+		snap := snapByProfile[profile]
+		if err := m.addProfileArtifacts(in, profile, snap); err != nil {
+			return BenchmarkMap{}, err
+		}
+	}
+
+	return m, nil
+}
+
+func copyReadingGuide() map[string]string {
+	out := make(map[string]string, len(defaultReadingGuide))
+	for k, v := range defaultReadingGuide {
+		out[k] = v
+	}
+	return out
+}
+
+func (m *BenchmarkMap) addMeasurements(in BuildInput) error {
+	abs := in.Layout.Measurement(in.Benchmark)
+	rel, err := in.Layout.RelFromLayout(abs)
+	if err != nil {
+		return err
+	}
+	section := &MeasurementsSection{
+		Path:        rel,
+		Purpose:     PurposeBenchmemResults,
+		Description: "Combined stdout from go test -bench with -benchmem.",
+	}
+	if summary, sumErr := parseMeasurementSummary(abs); sumErr == nil {
+		section.Summary = summary
+	}
+	m.Measurements = section
+	return nil
+}
+
+func (m *BenchmarkMap) addProfileArtifacts(in BuildInput, profile string, snap ProfileSnapshot) error {
+	profRel, err := in.Layout.RelFromLayout(in.Layout.ProfileBinary(in.Benchmark, profile))
+	if err != nil {
+		return err
+	}
+	m.Profiles[profile] = ProfileRef{
+		Path:         profRel,
+		Purpose:      PurposeRawPprofBinary,
+		Description:  "Raw pprof profile binary; source of truth for go tool pprof.",
+		TotalSamples: snapTotal(snap.ProfileData),
+	}
+	m.Status.Profiles[profile] = statusOK
+
+	hotRel, err := in.Layout.RelFromLayout(in.Layout.Hotspot(in.Benchmark, profile))
+	if err != nil {
+		return err
+	}
+	m.Hotspots[profile] = HotspotSection{
+		Path:        hotRel,
+		Purpose:     PurposeFlatCumulativeRanking,
+		Description: "go tool pprof -top output: flat time in function body, cum time including callees.",
+		Producer:    "go tool pprof -top",
+		TopSymbols:  topSymbols(snap.ProfileData, topSymbolLimit),
+	}
+	m.Status.Hotspots[profile] = statusOK
+
+	treeRel, err := in.Layout.RelFromLayout(in.Layout.CallTreeText(in.Benchmark, profile))
+	if err != nil {
+		return err
+	}
+	m.CallTrees[profile] = CallTreeSection{
+		Path:        treeRel,
+		Purpose:     PurposeCallerCalleeContext,
+		Description: "go tool pprof -tree output: caller/callee context for ranked nodes.",
+		Producer:    "go tool pprof -tree",
+		HotPath:     hotPathSummary(snap.ProfileData, hotPathLimit),
+	}
+	m.Status.CallTrees[profile] = statusOK
+
+	srcDir := in.Layout.SourceLinesDir(profile, in.Benchmark)
+	srcRel, err := in.Layout.RelFromLayout(srcDir)
+	if err != nil {
+		return err
+	}
+	m.SourceLines[profile] = SourceLinesSection{
+		Dir:         srcRel,
+		PathPattern: "source_lines/{profile}/{benchmark}/{output_stem}.txt",
+		Purpose:     PurposeLineLevelSource,
+		Description: "Per-function go tool pprof -list output with annotated source lines.",
+		Producer:    "go tool pprof -list",
+		Functions:   functionRefs(in, profile, snap),
+	}
+	m.Status.SourceLines[profile] = SourceLinesStatus{
+		Collected: snap.SourceLinesCollected,
+		Skipped:   snap.SourceLinesSkipped,
+		Failed:    snap.SourceLinesSkipped,
+	}
+
+	pngAbs := in.Layout.CallGraph(profile, in.Benchmark)
+	pngRel, err := in.Layout.RelFromLayout(pngAbs)
+	if err != nil {
+		return err
+	}
+	ref := CallGraphRef{
+		Path:        pngRel,
+		Purpose:     PurposeVisualCallGraph,
+		Description: "Optional Graphviz PNG from pprof; best-effort during collect.",
+	}
+	if _, statErr := os.Stat(pngAbs); statErr == nil {
+		ref.Status = statusOK
+		m.Status.CallGraphs[profile] = CallGraphStatus{Status: statusOK}
+	} else {
+		ref.Status = statusSkipped
+		ref.Reason = "not_generated"
+		m.Status.CallGraphs[profile] = CallGraphStatus{Status: statusSkipped, Reason: "not_generated"}
+	}
+	m.CallGraphs[profile] = ref
+
+	return nil
+}
+
+func snapTotal(d *parser.ProfileData) int64 {
+	if d == nil {
+		return 0
+	}
+	return d.Total
+}
+
+func topSymbols(d *parser.ProfileData, limit int) []TopSymbol {
+	if d == nil || len(d.SortedEntries) == 0 {
+		return nil
+	}
+	n := limit
+	if len(d.SortedEntries) < n {
+		n = len(d.SortedEntries)
+	}
+	out := make([]TopSymbol, 0, n)
+	for i := range n {
+		entry := d.SortedEntries[i]
+		out = append(out, TopSymbol{
+			Rank:    i + 1,
+			Symbol:  entry.Name,
+			Flat:    entry.Flat,
+			Cum:     d.Cum[entry.Name],
+			FlatPct: d.FlatPercentages[entry.Name],
+			CumPct:  d.CumPercentages[entry.Name],
+		})
+	}
+	return out
+}
+
+func hotPathSummary(d *parser.ProfileData, limit int) []string {
+	if d == nil {
+		return nil
+	}
+	n := limit
+	if len(d.SortedEntries) < n {
+		n = len(d.SortedEntries)
+	}
+	out := make([]string, 0, n)
+	for i := range n {
+		out = append(out, d.SortedEntries[i].Name)
+	}
+	return out
+}
+
+func functionRefs(in BuildInput, profile string, snap ProfileSnapshot) map[string]FunctionRef {
+	functions := make(map[string]FunctionRef, len(snap.ListEntries))
+	for _, e := range snap.ListEntries {
+		filePath := filepath.Join(in.Layout.SourceLinesDir(profile, in.Benchmark), e.OutputStem+"."+workspace.TextExtension)
+		rel, err := in.Layout.RelFromLayout(filePath)
+		if err != nil {
+			continue
+		}
+		status := statusOK
+		if snap.FailedStems != nil {
+			if _, failed := snap.FailedStems[e.OutputStem]; failed {
+				status = statusSkipped
+			}
+		}
+		ref := FunctionRef{
+			Path:       rel,
+			FullSymbol: e.FullSymbol,
+			Status:     status,
+		}
+		if snap.ProfileData != nil {
+			ref.Flat = snap.ProfileData.Flat[e.FullSymbol]
+			ref.Cum = snap.ProfileData.Cum[e.FullSymbol]
+			ref.FlatPct = snap.ProfileData.FlatPercentages[e.FullSymbol]
+			ref.CumPct = snap.ProfileData.CumPercentages[e.FullSymbol]
+		}
+		functions[e.OutputStem] = ref
+	}
+	if len(functions) == 0 {
+		return functions
+	}
+	// Stable key order not required for map; consumers iterate values.
+	return functions
+}
+
+// WriteJSON encodes m to path with standard permissions.
+func WriteJSON(path string, m BenchmarkMap) error {
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal benchmark map: %w", err)
+	}
+	if err = os.MkdirAll(filepath.Dir(path), workspace.PermDir); err != nil {
+		return fmt.Errorf("mkdir map parent: %w", err)
+	}
+	if err = os.WriteFile(path, data, workspace.PermFile); err != nil {
+		return fmt.Errorf("write benchmark map: %w", err)
+	}
+	return nil
+}
+
+// SortedProfileNames returns profile IDs in stable sorted order for tests.
+func SortedProfileNames(m BenchmarkMap) []string {
+	names := make([]string, 0, len(m.Profiles))
+	for name := range m.Profiles {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}

--- a/internal/datamap/build_test.go
+++ b/internal/datamap/build_test.go
@@ -1,0 +1,123 @@
+package datamap
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/AlexsanderHamir/prof/internal/workspace"
+	"github.com/AlexsanderHamir/prof/parser"
+)
+
+func TestBuild_minimalCPUProfile(t *testing.T) {
+	t.Parallel()
+	modRoot := t.TempDir()
+	layout := workspace.NewTagLayout(modRoot, "baseline")
+	bench := "BenchmarkFoo"
+
+	snap := ProfileSnapshot{
+		Profile: "cpu",
+		ProfileData: &parser.ProfileData{
+			Total: 100,
+			Flat:  map[string]int64{"main.work": 30},
+			Cum:   map[string]int64{"main.work": 80},
+			FlatPercentages: map[string]float64{
+				"main.work": 30,
+			},
+			CumPercentages: map[string]float64{
+				"main.work": 80,
+			},
+			SortedEntries: []parser.FuncEntry{
+				{Name: "main.work", Flat: 30},
+			},
+		},
+		ListEntries: []parser.FunctionListEntry{
+			{OutputStem: "work", FullSymbol: "main.work"},
+		},
+		SourceLinesCollected: 1,
+	}
+
+	m, err := Build(BuildInput{
+		Layout:         layout,
+		Tag:            "baseline",
+		Benchmark:      bench,
+		CollectionMode: collectionManual,
+		Profiles:       []string{"cpu"},
+		PerProfile:     []ProfileSnapshot{snap},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if m.SchemaVersion != SchemaVersion {
+		t.Fatalf("schema_version=%d", m.SchemaVersion)
+	}
+	if got := m.Hotspots["cpu"].Path; got != "hotspots/BenchmarkFoo/cpu.txt" {
+		t.Fatalf("hotspot path=%q", got)
+	}
+	fn := m.SourceLines["cpu"].Functions["work"]
+	if fn.FullSymbol != "main.work" || fn.Status != statusOK {
+		t.Fatalf("function ref=%+v", fn)
+	}
+	if len(m.Hotspots["cpu"].TopSymbols) != 1 {
+		t.Fatalf("top symbols=%d", len(m.Hotspots["cpu"].TopSymbols))
+	}
+}
+
+func TestWriteJSON_roundTrip(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	layout := workspace.NewTagLayout(dir, "t1")
+	path := layout.DataMapping("BenchmarkBar")
+
+	m := BenchmarkMap{
+		SchemaVersion: SchemaVersion,
+		Tag:           "t1",
+		Benchmark:     "BenchmarkBar",
+		Profiles:      map[string]ProfileRef{},
+		Hotspots:      map[string]HotspotSection{},
+		CallTrees:     map[string]CallTreeSection{},
+		SourceLines:   map[string]SourceLinesSection{},
+		Status: Status{
+			Profiles:    map[string]string{},
+			Hotspots:    map[string]string{},
+			CallTrees:   map[string]string{},
+			SourceLines: map[string]SourceLinesStatus{},
+		},
+	}
+	if err := WriteJSON(path, m); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"schema_version": 1`) {
+		t.Fatalf("json=%s", data)
+	}
+}
+
+func TestParseMeasurementSummary(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "run.txt")
+	content := `goos: linux
+BenchmarkFoo-8    1000    12345 ns/op    100 B/op    2 allocs/op
+PASS
+ok  	example.com/bench	1.234s
+`
+	if err := os.WriteFile(path, []byte(content), workspace.PermFile); err != nil {
+		t.Fatal(err)
+	}
+	sum, err := parseMeasurementSummary(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sum.NsPerOpMedian != 12345 || sum.BytesPerOp != 100 || sum.AllocsPerOp != 2 {
+		t.Fatalf("summary=%+v", sum)
+	}
+	if sum.Result != benchResultPass {
+		t.Fatalf("result=%q", sum.Result)
+	}
+}

--- a/internal/datamap/doc.go
+++ b/internal/datamap/doc.go
@@ -1,0 +1,3 @@
+// Package datamap defines the schema and builder for per-benchmark map.json
+// files under .prof/<tag>/data_mapping/<Benchmark>/.
+package datamap

--- a/internal/datamap/measurements.go
+++ b/internal/datamap/measurements.go
@@ -1,0 +1,68 @@
+package datamap
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+var benchLineRE = regexp.MustCompile(`^\S+\s+\d+\s+(\d+)\s+ns/op\s+(\d+)\s+B/op\s+(\d+)\s+allocs/op`)
+
+const benchResultPass = "PASS"
+
+func parseMeasurementSummary(path string) (*MeasurementSummary, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var nsValues []int64
+	var bytesPerOp, allocsPerOp int64
+	result := ""
+	var elapsed float64
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "ok\t") {
+			fields := strings.Fields(line)
+			if len(fields) >= 2 {
+				if d, parseErr := strconv.ParseFloat(strings.TrimSuffix(fields[len(fields)-1], "s"), 64); parseErr == nil {
+					elapsed = d
+				}
+			}
+		}
+		if line == benchResultPass {
+			result = benchResultPass
+		}
+		m := benchLineRE.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		ns, _ := strconv.ParseInt(m[1], 10, 64)
+		nsValues = append(nsValues, ns)
+		bytesPerOp, _ = strconv.ParseInt(m[2], 10, 64)
+		allocsPerOp, _ = strconv.ParseInt(m[3], 10, 64)
+	}
+	if err = scanner.Err(); err != nil {
+		return nil, err
+	}
+	if len(nsValues) == 0 {
+		return nil, fmt.Errorf("no benchmark lines in %s", path)
+	}
+	sort.Slice(nsValues, func(i, j int) bool { return nsValues[i] < nsValues[j] })
+	median := nsValues[len(nsValues)/2]
+	return &MeasurementSummary{
+		Count:          len(nsValues),
+		NsPerOpMedian:  median,
+		BytesPerOp:     bytesPerOp,
+		AllocsPerOp:    allocsPerOp,
+		ElapsedSeconds: elapsed,
+		Result:         result,
+	}, nil
+}

--- a/internal/datamap/types.go
+++ b/internal/datamap/types.go
@@ -1,0 +1,154 @@
+package datamap
+
+// SchemaVersion is the map.json schema version written by prof.
+const SchemaVersion = 1
+
+// Purpose values for artifact sections (stable enums for LLM consumers).
+const (
+	PurposeBenchmemResults       = "go_test_benchmem_results"
+	PurposeRawPprofBinary        = "raw_pprof_binary"
+	PurposeFlatCumulativeRanking = "flat_and_cumulative_ranking"
+	PurposeCallerCalleeContext   = "caller_callee_context"
+	PurposeLineLevelSource       = "line_level_source_extract"
+	PurposeVisualCallGraph       = "visual_call_graph"
+)
+
+// BenchmarkMap is the root document written to data_mapping/<Benchmark>/map.json.
+type BenchmarkMap struct {
+	SchemaVersion   int                           `json:"schema_version"`
+	Tag             string                        `json:"tag"`
+	Benchmark       string                        `json:"benchmark"`
+	Package         string                        `json:"package,omitempty"`
+	RecommendedFlow []string                      `json:"recommended_flow"`
+	ReadingGuide    map[string]string             `json:"reading_guide"`
+	Measurements    *MeasurementsSection          `json:"measurements,omitempty"`
+	Profiles        map[string]ProfileRef         `json:"profiles"`
+	Hotspots        map[string]HotspotSection     `json:"hotspots"`
+	CallTrees       map[string]CallTreeSection    `json:"call_trees"`
+	SourceLines     map[string]SourceLinesSection `json:"source_lines"`
+	CallGraphs      map[string]CallGraphRef       `json:"call_graphs,omitempty"`
+	Provenance      Provenance                    `json:"provenance"`
+	Status          Status                        `json:"status"`
+}
+
+// MeasurementsSection points at go test bench output.
+type MeasurementsSection struct {
+	Path        string              `json:"path"`
+	Purpose     string              `json:"purpose"`
+	Description string              `json:"description"`
+	Summary     *MeasurementSummary `json:"summary,omitempty"`
+}
+
+// MeasurementSummary holds parsed headline numbers from run.txt.
+type MeasurementSummary struct {
+	Count          int     `json:"count,omitempty"`
+	NsPerOpMedian  int64   `json:"ns_per_op_median,omitempty"`
+	BytesPerOp     int64   `json:"bytes_per_op,omitempty"`
+	AllocsPerOp    int64   `json:"allocs_per_op,omitempty"`
+	ElapsedSeconds float64 `json:"elapsed_seconds,omitempty"`
+	Result         string  `json:"result,omitempty"`
+}
+
+// ProfileRef describes a raw pprof binary.
+type ProfileRef struct {
+	Path         string `json:"path"`
+	Purpose      string `json:"purpose"`
+	Description  string `json:"description"`
+	TotalSamples int64  `json:"total_samples,omitempty"`
+}
+
+// HotspotSection describes a pprof -top text artifact.
+type HotspotSection struct {
+	Path        string      `json:"path"`
+	Purpose     string      `json:"purpose"`
+	Description string      `json:"description"`
+	Producer    string      `json:"producer"`
+	TopSymbols  []TopSymbol `json:"top_symbols,omitempty"`
+}
+
+// TopSymbol is one ranked row from hotspot data.
+type TopSymbol struct {
+	Rank    int     `json:"rank"`
+	Symbol  string  `json:"symbol"`
+	Flat    int64   `json:"flat"`
+	Cum     int64   `json:"cum"`
+	FlatPct float64 `json:"flat_pct"`
+	CumPct  float64 `json:"cum_pct"`
+}
+
+// CallTreeSection describes a pprof -tree text artifact.
+type CallTreeSection struct {
+	Path        string   `json:"path"`
+	Purpose     string   `json:"purpose"`
+	Description string   `json:"description"`
+	Producer    string   `json:"producer"`
+	HotPath     []string `json:"hot_path_summary,omitempty"`
+}
+
+// SourceLinesSection indexes per-function -list extracts for one profile kind.
+type SourceLinesSection struct {
+	Dir         string                 `json:"dir"`
+	PathPattern string                 `json:"path_pattern"`
+	Purpose     string                 `json:"purpose"`
+	Description string                 `json:"description"`
+	Producer    string                 `json:"producer"`
+	Functions   map[string]FunctionRef `json:"functions"`
+}
+
+// FunctionRef is one source_lines extract.
+type FunctionRef struct {
+	Path       string  `json:"path"`
+	FullSymbol string  `json:"full_symbol"`
+	Flat       int64   `json:"flat,omitempty"`
+	Cum        int64   `json:"cum,omitempty"`
+	FlatPct    float64 `json:"flat_pct,omitempty"`
+	CumPct     float64 `json:"cum_pct,omitempty"`
+	Status     string  `json:"status"`
+}
+
+// CallGraphRef describes an optional PNG call graph.
+type CallGraphRef struct {
+	Path        string `json:"path"`
+	Purpose     string `json:"purpose"`
+	Description string `json:"description"`
+	Status      string `json:"status"`
+	Reason      string `json:"reason,omitempty"`
+}
+
+// Provenance records how the map was produced.
+type Provenance struct {
+	Tag               string         `json:"tag"`
+	CollectionMode    string         `json:"collection_mode"`
+	BenchCount        int            `json:"bench_count,omitempty"`
+	ProfilesRequested []string       `json:"profiles_requested"`
+	Filter            FilterSnapshot `json:"filter"`
+}
+
+// FilterSnapshot mirrors prof.json function filter at collect time.
+type FilterSnapshot struct {
+	IncludePrefixes []string `json:"include_prefixes,omitempty"`
+	IgnoreFunctions []string `json:"ignore_functions,omitempty"`
+}
+
+// Status summarizes artifact availability.
+type Status struct {
+	BenchmarkRun string                       `json:"benchmark_run,omitempty"`
+	Profiles     map[string]string            `json:"profiles"`
+	Hotspots     map[string]string            `json:"hotspots"`
+	CallTrees    map[string]string            `json:"call_trees"`
+	CallGraphs   map[string]CallGraphStatus   `json:"call_graphs,omitempty"`
+	SourceLines  map[string]SourceLinesStatus `json:"source_lines"`
+}
+
+// CallGraphStatus reports PNG availability for one profile.
+type CallGraphStatus struct {
+	Status string `json:"status"`
+	Reason string `json:"reason,omitempty"`
+}
+
+// SourceLinesStatus counts per-function list results.
+type SourceLinesStatus struct {
+	Collected int `json:"collected"`
+	Skipped   int `json:"skipped"`
+	Failed    int `json:"failed"`
+}

--- a/internal/workspace/const.go
+++ b/internal/workspace/const.go
@@ -10,6 +10,8 @@ const (
 	CallTreesDir             = "call_trees"
 	SourceLinesDir           = "source_lines"
 	CallGraphsDir            = "call_graphs"
+	DataMappingDir           = "data_mapping"
+	DataMappingFile          = "map.json"
 	MeasurementRunFile       = "run.txt"
 	TagNotesFileName         = "notes.txt"
 	TagNotesPlaceholder      = "The explanation for this profiling session goes here"

--- a/internal/workspace/layout.go
+++ b/internal/workspace/layout.go
@@ -68,6 +68,20 @@ func (l TagLayout) CallGraph(profile, bench string) string {
 	return filepath.Join(l.Root, CallGraphsDir, profile, bench, fmt.Sprintf("%s.png", profile))
 }
 
+// DataMapping returns the per-benchmark navigation map JSON path.
+func (l TagLayout) DataMapping(bench string) string {
+	return filepath.Join(l.Root, DataMappingDir, bench, DataMappingFile)
+}
+
+// RelFromTagRoot returns absPath relative to tagRoot using forward slashes for portable JSON.
+func RelFromTagRoot(tagRoot, absPath string) (string, error) {
+	rel, err := filepath.Rel(tagRoot, absPath)
+	if err != nil {
+		return "", fmt.Errorf("rel from tag root: %w", err)
+	}
+	return filepath.ToSlash(rel), nil
+}
+
 // ResolveProfileBinary returns the binary profile path when it exists and is readable.
 func (l TagLayout) ResolveProfileBinary(bench, profile string) (string, error) {
 	p := l.ProfileBinary(bench, profile)
@@ -75,4 +89,9 @@ func (l TagLayout) ResolveProfileBinary(bench, profile string) (string, error) {
 		return "", err
 	}
 	return p, nil
+}
+
+// RelFromLayout returns path relative to the tag root for one layout-resolved absolute path.
+func (l TagLayout) RelFromLayout(absPath string) (string, error) {
+	return RelFromTagRoot(l.Root, absPath)
 }

--- a/internal/workspace/layout_test.go
+++ b/internal/workspace/layout_test.go
@@ -50,6 +50,11 @@ func TestTagLayout_paths(t *testing.T) {
 			l.CallGraph("cpu", "BenchmarkFoo"),
 			filepath.Join(root, workspace.MainDirOutput, "v1", "call_graphs", "cpu", "BenchmarkFoo", "cpu.png"),
 		},
+		{
+			"data mapping",
+			l.DataMapping("BenchmarkFoo"),
+			filepath.Join(root, workspace.MainDirOutput, "v1", "data_mapping", "BenchmarkFoo", "map.json"),
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -58,6 +63,20 @@ func TestTagLayout_paths(t *testing.T) {
 				t.Fatalf("got %q want %q", tc.got, tc.want)
 			}
 		})
+	}
+}
+
+func TestRelFromTagRoot(t *testing.T) {
+	t.Parallel()
+	tagRoot := filepath.Join(t.TempDir(), ".prof", "v1")
+	abs := filepath.Join(tagRoot, "hotspots", "BenchmarkFoo", "cpu.txt")
+	got, err := workspace.RelFromTagRoot(tagRoot, abs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "hotspots/BenchmarkFoo/cpu.txt"
+	if got != want {
+		t.Fatalf("got %q want %q", got, want)
 	}
 }
 

--- a/parser/facade.go
+++ b/parser/facade.go
@@ -42,11 +42,17 @@ func GetAllFunctionNamesFromProfileData(d *ProfileData, filter config.FunctionFi
 
 // GetFunctionListEntriesV2 loads a profile path and returns [FunctionListEntry] values using filter rules.
 func GetFunctionListEntriesV2(profilePath string, filter config.FunctionFilter) ([]FunctionListEntry, error) {
+	entries, _, err := GetFunctionListEntriesWithProfileData(profilePath, filter)
+	return entries, err
+}
+
+// GetFunctionListEntriesWithProfileData loads a profile once and returns list entries plus aggregated data.
+func GetFunctionListEntriesWithProfileData(profilePath string, filter config.FunctionFilter) ([]FunctionListEntry, *ProfileData, error) {
 	d, err := profileDataFromPath(profilePath)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return GetFunctionListEntriesFromProfileData(d, filter), nil
+	return GetFunctionListEntriesFromProfileData(d, filter), d, nil
 }
 
 // GetAllFunctionNamesV2 extracts short function names from a profile path using filter rules.

--- a/prof_web_doc/docs/workspace.md
+++ b/prof_web_doc/docs/workspace.md
@@ -28,6 +28,7 @@ Using Prof creates a `.prof/` tree next to your module, one folder per run (tag)
 | `.prof/<tag>/call_trees/<BenchmarkName>/` | Call-tree text (`pprof -tree`) per profile. |
 | `.prof/<tag>/source_lines/<profile>/<BenchmarkName>/` | Per-function `pprof -list` extracts when configured. |
 | `.prof/<tag>/call_graphs/<profile>/<BenchmarkName>/` | Optional Graphviz PNG call graphs when installed. |
+| `.prof/<tag>/data_mapping/<BenchmarkName>/map.json` | Machine-readable index of artifacts for this benchmark (paths, semantics, top symbols, function inventory). |
 | `.prof/<tag>/notes.txt` | Short tag-level note (placeholder until you edit it). |
 | `prof.json` | Active config next to `go.mod` after `prof config init` or **Manage configuration** in `prof ui`. |
 | `prof.json.example` | Commented reference (not loaded); copy optional sections into `prof.json`. See [Configure — generated files](configure.md#generated-files). |


### PR DESCRIPTION
## Summary
- Adds `.prof/<tag>/data_mapping/<Benchmark>/map.json` — a machine-readable index of hotspots, call_trees, source_lines, measurements, and profiles for LLM/agent navigation.
- New `internal/datamap` package owns the JSON schema and pure builder; collect wiring is a single emit call per benchmark (auto + manual).
- Paths in JSON are relative to the tag root; top symbols and function inventory come from existing ProfileData (no extra pprof runs).

## Motivation
Agents currently scan `.prof/` or read large hotspot files to discover artifacts. map.json provides semantics, reading order, and triage summaries in one file.

## Test plan
- [x] `go test ./internal/workspace/ ./internal/datamap/ ./engine/collect/ -count=1`
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [ ] `prof auto` on one benchmark; confirm map.json validates and paths resolve relative to tag root

## Out of scope
Tag manifest, triage_hint synthesis, JSON Schema file.

Made with [Cursor](https://cursor.com)