### PR TITLE
polish(datamap): pprof-aligned metrics and mapping-only map.json

### DIFF
--- a/docs/design/benchmark-data-map.md
+++ b/docs/design/benchmark-data-map.md
@@ -103,6 +103,22 @@ Schema types and builder live in [`internal/datamap`](../../internal/datamap/). 
 }
 ```
 
+## Sample units and display fields
+
+`flat` / `cum` / `total_samples` are **raw profile sample values** in the pprof sample unit (nanoseconds for CPU, bytes for heap profiles). They use the **last** `SampleType` index — the same index `go tool pprof -top` uses via `report.NewDefault`.
+
+Display strings match `go tool pprof -top` exactly:
+
+| Field | Meaning |
+| --- | --- |
+| `sample_unit` | Raw unit from the profile (e.g. `nanoseconds`, `bytes`) |
+| `output_unit` | Single display unit chosen for the whole report (pprof `selectOutputUnit`, e.g. `s`, `MB`) |
+| `flat_display` / `cum_display` | Formatted flat/cum using pprof `ScaledLabel` with `output_unit` |
+| `flat_seconds` / `cum_seconds` | Numeric seconds when `sample_unit` is time (independent of display suffix) |
+| `total_display` / `total_seconds` | Profile total in the same display rules as `-top` header |
+
+Implementation: [`internal/pprofscale`](../../internal/pprofscale/) (copied from `github.com/google/pprof/internal/measurement` because that package is internal).
+
 ## Invariants
 
 - Same `FunctionListEntry` set as source_lines on disk (from `prof.json` filters).

--- a/docs/design/benchmark-data-map.md
+++ b/docs/design/benchmark-data-map.md
@@ -103,6 +103,22 @@ Schema types and builder live in [`internal/datamap`](../../internal/datamap/). 
 }
 ```
 
+## Profile cost columns (flat / cum)
+
+`go tool pprof -top` prints five metric columns. The same concepts appear in `map.json` as `flat`, `cum`, `flat_pct`, and `cum_pct` on `top_symbols` and `source_lines.functions`:
+
+| Column | In map.json | Meaning |
+| --- | --- | --- |
+| `flat` | `flat`, `flat_display`, `flat_seconds` | Cost in this function's own code only (excludes callees). CPU: time in the function body; memory: bytes allocated there. |
+| `flat%` | `flat_pct` | `flat` as % of total profile samples. |
+| `sum%` | *(not stored)* | Running sum of `flat%` reading the `-top` table top to bottom. |
+| `cum` | `cum`, `cum_display`, `cum_seconds` | Cost in this function plus all functions it called. CPU: seconds; memory: bytes including callees. |
+| `cum%` | `cum_pct` | `cum` as % of total profile samples. |
+
+Each emitted `map.json` includes `profile_cost_columns` and `profile_cost_triage`:
+
+> High flat: optimize this function's body. High cum but low flat: work is mostly in callees — check call_trees or child symbols.
+
 ## Sample units and display fields
 
 `flat` / `cum` / `total_samples` are **raw profile sample values** in the pprof sample unit (nanoseconds for CPU, bytes for heap profiles). They use the **last** `SampleType` index — the same index `go tool pprof -top` uses via `report.NewDefault`.

--- a/docs/design/benchmark-data-map.md
+++ b/docs/design/benchmark-data-map.md
@@ -30,10 +30,22 @@ Schema types and builder live in [`internal/datamap`](../../internal/datamap/). 
 ## Recommended reading flow
 
 1. **measurements** — confirm benchmark ran; headline ns/op and allocs
-2. **hotspots** — find top symbols (`top_symbols` in map)
-3. **call_trees** — understand call path (`hot_path_summary`)
-4. **source_lines** — line-level detail for chosen symbols
+2. **hotspots** — open linked `hotspots/*.txt` for flat/cum rankings (`profile_cost_columns` explains columns)
+3. **call_trees** — open linked `call_trees/*.txt` for caller/callee context
+4. **source_lines** — line-level detail for chosen symbols (path index only in map.json)
 5. **profiles** — raw binary only if deeper pprof queries needed
+
+## Mapping vs metrics
+
+`map.json` is an **artifact index**, not a copy of profile sample data.
+
+| Section | map.json holds | Metrics live in |
+| --- | --- | --- |
+| `hotspots` | Path to `-top` text + column glossary | `hotspots/<benchmark>/<profile>.txt` |
+| `source_lines.functions` | Path, `full_symbol`, `status` | Prior hotspots read; line detail in linked `.txt` |
+| `profiles` | Path + profile total (orientation) | Raw `.out` binary |
+
+Do not expect `flat`/`cum` on `source_lines` entries — agents reach source_lines after choosing a symbol from hotspots.
 
 ## Example (truncated)
 
@@ -59,14 +71,7 @@ Schema types and builder live in [`internal/datamap`](../../internal/datamap/). 
       "path": "hotspots/BenchmarkDataGeneration/cpu.txt",
       "purpose": "flat_and_cumulative_ranking",
       "producer": "go tool pprof -top",
-      "top_symbols": [
-        {
-          "rank": 1,
-          "symbol": "github.com/example/benchmarks/utils.(*DataGenerator).GenerateStrings",
-          "flat_pct": 1.28,
-          "cum_pct": 70.53
-        }
-      ]
+      "hotspots_metrics_note": "flat/cum rankings and sample values are in the hotspots text at path..."
     }
   },
   "call_trees": {
@@ -105,35 +110,25 @@ Schema types and builder live in [`internal/datamap`](../../internal/datamap/). 
 
 ## Profile cost columns (flat / cum)
 
-`go tool pprof -top` prints five metric columns. The same concepts appear in `map.json` as `flat`, `cum`, `flat_pct`, and `cum_pct` on `top_symbols` and `source_lines.functions`:
+`go tool pprof -top` prints five metric columns. Read them in `hotspots/*.txt`; `profile_cost_columns` in map.json explains each column:
 
-| Column | In map.json | Meaning |
-| --- | --- | --- |
-| `flat` | `flat`, `flat_display`, `flat_seconds` | Cost in this function's own code only (excludes callees). CPU: time in the function body; memory: bytes allocated there. |
-| `flat%` | `flat_pct` | `flat` as % of total profile samples. |
-| `sum%` | *(not stored)* | Running sum of `flat%` reading the `-top` table top to bottom. |
-| `cum` | `cum`, `cum_display`, `cum_seconds` | Cost in this function plus all functions it called. CPU: seconds; memory: bytes including callees. |
-| `cum%` | `cum_pct` | `cum` as % of total profile samples. |
+| Column | Meaning |
+| --- | --- |
+| `flat` | Cost in this function's own code only (excludes callees). CPU: time in the function body; memory: bytes allocated there. |
+| `flat%` | `flat` as % of total profile samples. |
+| `sum%` | Running sum of `flat%` reading the `-top` table top to bottom. |
+| `cum` | Cost in this function plus all functions it called. CPU: seconds; memory: bytes including callees. |
+| `cum%` | `cum` as % of total profile samples. |
 
-Each emitted `map.json` includes `profile_cost_columns` and `profile_cost_triage`:
+Each emitted `map.json` includes `profile_cost_columns` and `profile_cost_triage` so agents can interpret the hotspots text file:
 
 > High flat: optimize this function's body. High cum but low flat: work is mostly in callees — check call_trees or child symbols.
 
 ## Sample units and display fields
 
-`flat` / `cum` / `total_samples` are **raw profile sample values** in the pprof sample unit (nanoseconds for CPU, bytes for heap profiles). They use the **last** `SampleType` index — the same index `go tool pprof -top` uses via `report.NewDefault`.
+`flat` / `cum` / `total_samples` on the **profiles** section are raw profile totals in the pprof sample unit (nanoseconds for CPU, bytes for heap profiles). Per-function metrics are **not** duplicated in map.json — read `hotspots/*.txt` instead.
 
-Display strings match `go tool pprof -top` exactly:
-
-| Field | Meaning |
-| --- | --- |
-| `sample_unit` | Raw unit from the profile (e.g. `nanoseconds`, `bytes`) |
-| `output_unit` | Single display unit chosen for the whole report (pprof `selectOutputUnit`, e.g. `s`, `MB`) |
-| `flat_display` / `cum_display` | Formatted flat/cum using pprof `ScaledLabel` with `output_unit` |
-| `flat_seconds` / `cum_seconds` | Numeric seconds when `sample_unit` is time (independent of display suffix) |
-| `total_display` / `total_seconds` | Profile total in the same display rules as `-top` header |
-
-Implementation: [`internal/pprofscale`](../../internal/pprofscale/) (copied from `github.com/google/pprof/internal/measurement` because that package is internal).
+Display strings on **profiles** (`total_display`, `total_seconds`) match the `go tool pprof -top` header. Implementation: [`internal/pprofscale`](../../internal/pprofscale/).
 
 ## Invariants
 
@@ -146,7 +141,7 @@ Implementation: [`internal/pprofscale`](../../internal/pprofscale/) (copied from
 
 **Positive:** Agents load one JSON file to triage before opening large text artifacts.
 
-**Neutral:** map.json grows with function count; acceptable for v1.
+**Neutral:** map.json size scales with function count (path index only); much smaller than duplicating per-function metrics.
 
 ## Out of scope (v2)
 

--- a/engine/collect/datamap_emit_test.go
+++ b/engine/collect/datamap_emit_test.go
@@ -77,7 +77,7 @@ func TestEmitBenchmarkMap_writesMapJSON(t *testing.T) {
 	if len(m.SourceLines["cpu"].Functions) == 0 {
 		t.Fatal("expected source_lines functions")
 	}
-	if len(m.Hotspots["cpu"].TopSymbols) == 0 {
-		t.Fatal("expected top_symbols")
+	if m.Hotspots["cpu"].HotspotsMetricsNote == "" {
+		t.Fatal("expected hotspots_metrics_note")
 	}
 }

--- a/internal/datamap/build.go
+++ b/internal/datamap/build.go
@@ -22,7 +22,7 @@ const (
 
 var (
 	defaultRecommendedFlow = []string{"measurements", "hotspots", "call_trees", "source_lines", "profiles"}
-	defaultReadingGuide = map[string]string{
+	defaultReadingGuide    = map[string]string{
 		"measurements": "Go benchmark output (ns/op, B/op, allocs/op). Start here to confirm the run succeeded.",
 		"hotspots":     "pprof -top text at path; flat/cum metrics live there, not in map.json. See profile_cost_columns.",
 		"call_trees":   "pprof -tree: caller/callee context for top nodes.",
@@ -74,19 +74,19 @@ func Build(in BuildInput) (BenchmarkMap, error) {
 	}
 
 	m := BenchmarkMap{
-		SchemaVersion:   SchemaVersion,
-		Tag:             in.Tag,
-		Benchmark:       in.Benchmark,
-		Package:         in.Package,
+		SchemaVersion:      SchemaVersion,
+		Tag:                in.Tag,
+		Benchmark:          in.Benchmark,
+		Package:            in.Package,
 		RecommendedFlow:    append([]string(nil), defaultRecommendedFlow...),
 		ReadingGuide:       copyReadingGuide(),
 		ProfileCostColumns: copyProfileCostColumns(),
 		ProfileCostTriage:  defaultProfileCostTriage,
-		Profiles:        make(map[string]ProfileRef, len(in.Profiles)),
-		Hotspots:        make(map[string]HotspotSection, len(in.Profiles)),
-		CallTrees:       make(map[string]CallTreeSection, len(in.Profiles)),
-		SourceLines:     make(map[string]SourceLinesSection, len(in.Profiles)),
-		CallGraphs:      make(map[string]CallGraphRef, len(in.Profiles)),
+		Profiles:           make(map[string]ProfileRef, len(in.Profiles)),
+		Hotspots:           make(map[string]HotspotSection, len(in.Profiles)),
+		CallTrees:          make(map[string]CallTreeSection, len(in.Profiles)),
+		SourceLines:        make(map[string]SourceLinesSection, len(in.Profiles)),
+		CallGraphs:         make(map[string]CallGraphRef, len(in.Profiles)),
 		Status: Status{
 			Profiles:    make(map[string]string, len(in.Profiles)),
 			Hotspots:    make(map[string]string, len(in.Profiles)),
@@ -189,10 +189,10 @@ func (m *BenchmarkMap) addProfileArtifacts(in BuildInput, profile string, snap P
 		return err
 	}
 	m.Hotspots[profile] = HotspotSection{
-		Path:               hotRel,
-		Purpose:            PurposeFlatCumulativeRanking,
-		Description:        "go tool pprof -top output: flat time in function body, cum time including callees.",
-		Producer:           "go tool pprof -top",
+		Path:                hotRel,
+		Purpose:             PurposeFlatCumulativeRanking,
+		Description:         "go tool pprof -top output: flat time in function body, cum time including callees.",
+		Producer:            "go tool pprof -top",
 		HotspotsMetricsNote: hotspotsMetricsNote,
 	}
 	m.Status.Hotspots[profile] = statusOK

--- a/internal/datamap/build.go
+++ b/internal/datamap/build.go
@@ -14,8 +14,6 @@ import (
 )
 
 const (
-	topSymbolLimit   = 10
-	hotPathLimit     = 5
 	statusOK         = "ok"
 	statusSkipped    = "skipped"
 	collectionAuto   = "auto"
@@ -24,11 +22,11 @@ const (
 
 var (
 	defaultRecommendedFlow = []string{"measurements", "hotspots", "call_trees", "source_lines", "profiles"}
-	defaultReadingGuide    = map[string]string{
+	defaultReadingGuide = map[string]string{
 		"measurements": "Go benchmark output (ns/op, B/op, allocs/op). Start here to confirm the run succeeded.",
-		"hotspots":     "pprof -top table; see profile_cost_columns for flat/cum column meanings.",
+		"hotspots":     "pprof -top text at path; flat/cum metrics live there, not in map.json. See profile_cost_columns.",
 		"call_trees":   "pprof -tree: caller/callee context for top nodes.",
-		"source_lines": "pprof -list extracts per function; use on symbols chosen from hotspots.",
+		"source_lines": "pprof -list extract paths per function; open the linked .txt for line-level detail.",
 		"profiles":     "Raw .out binaries; re-query with go tool pprof when text is insufficient.",
 	}
 	defaultProfileCostColumns = map[string]string{
@@ -39,6 +37,7 @@ var (
 		"cum_pct":  "cum as % of total profile samples. Same as cum% in hotspots/*.txt; map.json field cum_pct.",
 	}
 	defaultProfileCostTriage = "High flat: optimize this function's body. High cum but low flat: work is mostly in callees — check call_trees or child symbols."
+	hotspotsMetricsNote      = "flat/cum rankings and sample values are in the hotspots text at path (go tool pprof -top). map.json links artifacts only; use profile_cost_columns when reading that file."
 )
 
 // ProfileSnapshot captures in-memory state for one profile kind at map emit time.
@@ -190,13 +189,11 @@ func (m *BenchmarkMap) addProfileArtifacts(in BuildInput, profile string, snap P
 		return err
 	}
 	m.Hotspots[profile] = HotspotSection{
-		Path:        hotRel,
-		Purpose:     PurposeFlatCumulativeRanking,
-		Description: "go tool pprof -top output: flat time in function body, cum time including callees.",
-		Producer:    "go tool pprof -top",
-		SampleUnit:  sampleUnit(snap.ProfileData),
-		OutputUnit:  profileOutputUnit(snap.ProfileData),
-		TopSymbols:  topSymbols(snap.ProfileData, topSymbolLimit),
+		Path:               hotRel,
+		Purpose:            PurposeFlatCumulativeRanking,
+		Description:        "go tool pprof -top output: flat time in function body, cum time including callees.",
+		Producer:           "go tool pprof -top",
+		HotspotsMetricsNote: hotspotsMetricsNote,
 	}
 	m.Status.Hotspots[profile] = statusOK
 
@@ -209,7 +206,6 @@ func (m *BenchmarkMap) addProfileArtifacts(in BuildInput, profile string, snap P
 		Purpose:     PurposeCallerCalleeContext,
 		Description: "go tool pprof -tree output: caller/callee context for ranked nodes.",
 		Producer:    "go tool pprof -tree",
-		HotPath:     hotPathSummary(snap.ProfileData, hotPathLimit),
 	}
 	m.Status.CallTrees[profile] = statusOK
 
@@ -269,52 +265,6 @@ func sampleUnit(d *parser.ProfileData) string {
 	return d.SampleUnit
 }
 
-func topSymbols(d *parser.ProfileData, limit int) []TopSymbol {
-	if d == nil || len(d.SortedEntries) == 0 {
-		return nil
-	}
-	n := limit
-	if len(d.SortedEntries) < n {
-		n = len(d.SortedEntries)
-	}
-	unit := d.SampleUnit
-	outUnit := profileOutputUnit(d)
-	out := make([]TopSymbol, 0, n)
-	for i := range n {
-		entry := d.SortedEntries[i]
-		cum := d.Cum[entry.Name]
-		flatDisp, cumDisp, flatSec, cumSec := sampleDisplays(entry.Flat, cum, unit, outUnit)
-		out = append(out, TopSymbol{
-			Rank:        i + 1,
-			Symbol:      entry.Name,
-			Flat:        entry.Flat,
-			Cum:         cum,
-			FlatDisplay: flatDisp,
-			CumDisplay:  cumDisp,
-			FlatSeconds: flatSec,
-			CumSeconds:  cumSec,
-			FlatPct:     d.FlatPercentages[entry.Name],
-			CumPct:      d.CumPercentages[entry.Name],
-		})
-	}
-	return out
-}
-
-func hotPathSummary(d *parser.ProfileData, limit int) []string {
-	if d == nil {
-		return nil
-	}
-	n := limit
-	if len(d.SortedEntries) < n {
-		n = len(d.SortedEntries)
-	}
-	out := make([]string, 0, n)
-	for i := range n {
-		out = append(out, d.SortedEntries[i].Name)
-	}
-	return out
-}
-
 func functionRefs(in BuildInput, profile string, snap ProfileSnapshot) map[string]FunctionRef {
 	functions := make(map[string]FunctionRef, len(snap.ListEntries))
 	for _, e := range snap.ListEntries {
@@ -333,20 +283,6 @@ func functionRefs(in BuildInput, profile string, snap ProfileSnapshot) map[strin
 			Path:       rel,
 			FullSymbol: e.FullSymbol,
 			Status:     status,
-		}
-		if snap.ProfileData != nil {
-			outUnit := profileOutputUnit(snap.ProfileData)
-			flat := snap.ProfileData.Flat[e.FullSymbol]
-			cum := snap.ProfileData.Cum[e.FullSymbol]
-			flatDisp, cumDisp, flatSec, cumSec := sampleDisplays(flat, cum, snap.ProfileData.SampleUnit, outUnit)
-			ref.Flat = flat
-			ref.Cum = cum
-			ref.FlatDisplay = flatDisp
-			ref.CumDisplay = cumDisp
-			ref.FlatSeconds = flatSec
-			ref.CumSeconds = cumSec
-			ref.FlatPct = snap.ProfileData.FlatPercentages[e.FullSymbol]
-			ref.CumPct = snap.ProfileData.CumPercentages[e.FullSymbol]
 		}
 		functions[e.OutputStem] = ref
 	}

--- a/internal/datamap/build.go
+++ b/internal/datamap/build.go
@@ -155,6 +155,15 @@ func (m *BenchmarkMap) addProfileArtifacts(in BuildInput, profile string, snap P
 		Purpose:      PurposeRawPprofBinary,
 		Description:  "Raw pprof profile binary; source of truth for go tool pprof.",
 		TotalSamples: snapTotal(snap.ProfileData),
+		SampleUnit:   sampleUnit(snap.ProfileData),
+	}
+	if snap.ProfileData != nil {
+		display, sec, outUnit := profileTotalDisplay(snap.ProfileData)
+		ref := m.Profiles[profile]
+		ref.TotalDisplay = display
+		ref.TotalSeconds = sec
+		ref.OutputUnit = outUnit
+		m.Profiles[profile] = ref
 	}
 	m.Status.Profiles[profile] = statusOK
 
@@ -167,6 +176,8 @@ func (m *BenchmarkMap) addProfileArtifacts(in BuildInput, profile string, snap P
 		Purpose:     PurposeFlatCumulativeRanking,
 		Description: "go tool pprof -top output: flat time in function body, cum time including callees.",
 		Producer:    "go tool pprof -top",
+		SampleUnit:  sampleUnit(snap.ProfileData),
+		OutputUnit:  profileOutputUnit(snap.ProfileData),
 		TopSymbols:  topSymbols(snap.ProfileData, topSymbolLimit),
 	}
 	m.Status.Hotspots[profile] = statusOK
@@ -233,6 +244,13 @@ func snapTotal(d *parser.ProfileData) int64 {
 	return d.Total
 }
 
+func sampleUnit(d *parser.ProfileData) string {
+	if d == nil {
+		return ""
+	}
+	return d.SampleUnit
+}
+
 func topSymbols(d *parser.ProfileData, limit int) []TopSymbol {
 	if d == nil || len(d.SortedEntries) == 0 {
 		return nil
@@ -241,16 +259,24 @@ func topSymbols(d *parser.ProfileData, limit int) []TopSymbol {
 	if len(d.SortedEntries) < n {
 		n = len(d.SortedEntries)
 	}
+	unit := d.SampleUnit
+	outUnit := profileOutputUnit(d)
 	out := make([]TopSymbol, 0, n)
 	for i := range n {
 		entry := d.SortedEntries[i]
+		cum := d.Cum[entry.Name]
+		flatDisp, cumDisp, flatSec, cumSec := sampleDisplays(entry.Flat, cum, unit, outUnit)
 		out = append(out, TopSymbol{
-			Rank:    i + 1,
-			Symbol:  entry.Name,
-			Flat:    entry.Flat,
-			Cum:     d.Cum[entry.Name],
-			FlatPct: d.FlatPercentages[entry.Name],
-			CumPct:  d.CumPercentages[entry.Name],
+			Rank:        i + 1,
+			Symbol:      entry.Name,
+			Flat:        entry.Flat,
+			Cum:         cum,
+			FlatDisplay: flatDisp,
+			CumDisplay:  cumDisp,
+			FlatSeconds: flatSec,
+			CumSeconds:  cumSec,
+			FlatPct:     d.FlatPercentages[entry.Name],
+			CumPct:      d.CumPercentages[entry.Name],
 		})
 	}
 	return out
@@ -291,8 +317,16 @@ func functionRefs(in BuildInput, profile string, snap ProfileSnapshot) map[strin
 			Status:     status,
 		}
 		if snap.ProfileData != nil {
-			ref.Flat = snap.ProfileData.Flat[e.FullSymbol]
-			ref.Cum = snap.ProfileData.Cum[e.FullSymbol]
+			outUnit := profileOutputUnit(snap.ProfileData)
+			flat := snap.ProfileData.Flat[e.FullSymbol]
+			cum := snap.ProfileData.Cum[e.FullSymbol]
+			flatDisp, cumDisp, flatSec, cumSec := sampleDisplays(flat, cum, snap.ProfileData.SampleUnit, outUnit)
+			ref.Flat = flat
+			ref.Cum = cum
+			ref.FlatDisplay = flatDisp
+			ref.CumDisplay = cumDisp
+			ref.FlatSeconds = flatSec
+			ref.CumSeconds = cumSec
 			ref.FlatPct = snap.ProfileData.FlatPercentages[e.FullSymbol]
 			ref.CumPct = snap.ProfileData.CumPercentages[e.FullSymbol]
 		}

--- a/internal/datamap/build.go
+++ b/internal/datamap/build.go
@@ -26,11 +26,19 @@ var (
 	defaultRecommendedFlow = []string{"measurements", "hotspots", "call_trees", "source_lines", "profiles"}
 	defaultReadingGuide    = map[string]string{
 		"measurements": "Go benchmark output (ns/op, B/op, allocs/op). Start here to confirm the run succeeded.",
-		"hotspots":     "pprof -top: functions ranked by flat and cumulative cost.",
+		"hotspots":     "pprof -top table; see profile_cost_columns for flat/cum column meanings.",
 		"call_trees":   "pprof -tree: caller/callee context for top nodes.",
 		"source_lines": "pprof -list extracts per function; use on symbols chosen from hotspots.",
 		"profiles":     "Raw .out binaries; re-query with go tool pprof when text is insufficient.",
 	}
+	defaultProfileCostColumns = map[string]string{
+		"flat":     "Cost in this function's own code only (excludes callees). CPU: seconds in the function body; memory: bytes allocated there.",
+		"flat_pct": "flat as % of total profile samples. Same as flat% in hotspots/*.txt; map.json field flat_pct.",
+		"sum_pct":  "Running sum of flat% reading the -top table top to bottom. Column in hotspots/*.txt only (not stored in map.json).",
+		"cum":      "Cost in this function plus all functions it called (transitive). CPU: seconds; memory: bytes including callees.",
+		"cum_pct":  "cum as % of total profile samples. Same as cum% in hotspots/*.txt; map.json field cum_pct.",
+	}
+	defaultProfileCostTriage = "High flat: optimize this function's body. High cum but low flat: work is mostly in callees — check call_trees or child symbols."
 )
 
 // ProfileSnapshot captures in-memory state for one profile kind at map emit time.
@@ -71,8 +79,10 @@ func Build(in BuildInput) (BenchmarkMap, error) {
 		Tag:             in.Tag,
 		Benchmark:       in.Benchmark,
 		Package:         in.Package,
-		RecommendedFlow: append([]string(nil), defaultRecommendedFlow...),
-		ReadingGuide:    copyReadingGuide(),
+		RecommendedFlow:    append([]string(nil), defaultRecommendedFlow...),
+		ReadingGuide:       copyReadingGuide(),
+		ProfileCostColumns: copyProfileCostColumns(),
+		ProfileCostTriage:  defaultProfileCostTriage,
 		Profiles:        make(map[string]ProfileRef, len(in.Profiles)),
 		Hotspots:        make(map[string]HotspotSection, len(in.Profiles)),
 		CallTrees:       make(map[string]CallTreeSection, len(in.Profiles)),
@@ -122,6 +132,14 @@ func Build(in BuildInput) (BenchmarkMap, error) {
 func copyReadingGuide() map[string]string {
 	out := make(map[string]string, len(defaultReadingGuide))
 	for k, v := range defaultReadingGuide {
+		out[k] = v
+	}
+	return out
+}
+
+func copyProfileCostColumns() map[string]string {
+	out := make(map[string]string, len(defaultProfileCostColumns))
+	for k, v := range defaultProfileCostColumns {
 		out[k] = v
 	}
 	return out

--- a/internal/datamap/build_test.go
+++ b/internal/datamap/build_test.go
@@ -63,6 +63,12 @@ func TestBuild_minimalCPUProfile(t *testing.T) {
 	if len(m.Hotspots["cpu"].TopSymbols) != 1 {
 		t.Fatalf("top symbols=%d", len(m.Hotspots["cpu"].TopSymbols))
 	}
+	if m.ProfileCostColumns["flat"] == "" || m.ProfileCostColumns["cum_pct"] == "" {
+		t.Fatal("expected profile_cost_columns glossary")
+	}
+	if m.ProfileCostTriage == "" {
+		t.Fatal("expected profile_cost_triage")
+	}
 }
 
 func TestWriteJSON_roundTrip(t *testing.T) {

--- a/internal/datamap/build_test.go
+++ b/internal/datamap/build_test.go
@@ -60,8 +60,8 @@ func TestBuild_minimalCPUProfile(t *testing.T) {
 	if fn.FullSymbol != "main.work" || fn.Status != statusOK {
 		t.Fatalf("function ref=%+v", fn)
 	}
-	if len(m.Hotspots["cpu"].TopSymbols) != 1 {
-		t.Fatalf("top symbols=%d", len(m.Hotspots["cpu"].TopSymbols))
+	if m.Hotspots["cpu"].HotspotsMetricsNote == "" {
+		t.Fatal("expected hotspots_metrics_note on hotspot section")
 	}
 	if m.ProfileCostColumns["flat"] == "" || m.ProfileCostColumns["cum_pct"] == "" {
 		t.Fatal("expected profile_cost_columns glossary")

--- a/internal/datamap/display.go
+++ b/internal/datamap/display.go
@@ -1,0 +1,40 @@
+package datamap
+
+import (
+	"github.com/AlexsanderHamir/prof/internal/pprofscale"
+	"github.com/AlexsanderHamir/prof/parser"
+)
+
+func profileOutputUnit(d *parser.ProfileData) string {
+	if d == nil || d.SampleUnit == "" {
+		return "auto"
+	}
+	return pprofscale.SelectOutputUnit(d.SampleUnit, d.Total, d.Flat, d.Cum)
+}
+
+func sampleDisplays(flat, cum int64, unit, outputUnit string) (flatDisplay, cumDisplay string, flatSec, cumSec float64) {
+	if unit == "" {
+		return "", "", 0, 0
+	}
+	flatDisplay = pprofscale.ScaledLabel(flat, unit, outputUnit)
+	cumDisplay = pprofscale.ScaledLabel(cum, unit, outputUnit)
+	if s, ok := pprofscale.Seconds(flat, unit); ok {
+		flatSec = pprofscale.RoundSeconds(s)
+	}
+	if s, ok := pprofscale.Seconds(cum, unit); ok {
+		cumSec = pprofscale.RoundSeconds(s)
+	}
+	return flatDisplay, cumDisplay, flatSec, cumSec
+}
+
+func profileTotalDisplay(d *parser.ProfileData) (display string, seconds float64, outputUnit string) {
+	if d == nil || d.SampleUnit == "" {
+		return "", 0, ""
+	}
+	outputUnit = profileOutputUnit(d)
+	display = pprofscale.ScaledLabel(d.Total, d.SampleUnit, outputUnit)
+	if s, ok := pprofscale.Seconds(d.Total, d.SampleUnit); ok {
+		seconds = pprofscale.RoundSeconds(s)
+	}
+	return display, seconds, outputUnit
+}

--- a/internal/datamap/display.go
+++ b/internal/datamap/display.go
@@ -12,21 +12,6 @@ func profileOutputUnit(d *parser.ProfileData) string {
 	return pprofscale.SelectOutputUnit(d.SampleUnit, d.Total, d.Flat, d.Cum)
 }
 
-func sampleDisplays(flat, cum int64, unit, outputUnit string) (flatDisplay, cumDisplay string, flatSec, cumSec float64) {
-	if unit == "" {
-		return "", "", 0, 0
-	}
-	flatDisplay = pprofscale.ScaledLabel(flat, unit, outputUnit)
-	cumDisplay = pprofscale.ScaledLabel(cum, unit, outputUnit)
-	if s, ok := pprofscale.Seconds(flat, unit); ok {
-		flatSec = pprofscale.RoundSeconds(s)
-	}
-	if s, ok := pprofscale.Seconds(cum, unit); ok {
-		cumSec = pprofscale.RoundSeconds(s)
-	}
-	return flatDisplay, cumDisplay, flatSec, cumSec
-}
-
 func profileTotalDisplay(d *parser.ProfileData) (display string, seconds float64, outputUnit string) {
 	if d == nil || d.SampleUnit == "" {
 		return "", 0, ""

--- a/internal/datamap/display_test.go
+++ b/internal/datamap/display_test.go
@@ -1,0 +1,65 @@
+package datamap
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/AlexsanderHamir/prof/internal/pprofscale"
+	"github.com/AlexsanderHamir/prof/parser"
+)
+
+func cpuFixturePath(t *testing.T) string {
+	t.Helper()
+	for _, rel := range []string{
+		"tests/assets/fixtures/BenchmarkStringProcessor_cpu.out",
+		filepath.Join("..", "..", "tests", "assets", "fixtures", "BenchmarkStringProcessor_cpu.out"),
+	} {
+		if _, err := os.Stat(rel); err == nil {
+			return rel
+		}
+	}
+	t.Skip("cpu profile fixture not present")
+	return ""
+}
+
+// Top rows must match go tool pprof -top display strings (same Scale/ScaledLabel as pprof).
+func TestTopSymbolDisplay_matchesPprofTop(t *testing.T) {
+	t.Parallel()
+	path := cpuFixturePath(t)
+	d, err := parser.DefaultPipeline().RunFromPath(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d.SampleUnit != "nanoseconds" {
+		t.Fatalf("sample_unit=%q want nanoseconds", d.SampleUnit)
+	}
+
+	want := map[string]string{
+		"crypto/internal/fips140/sha256.blockSHANI": "0.19s",
+		"runtime.memmove":                           "0.16s",
+	}
+	for sym, label := range want {
+		flat, ok := d.Flat[sym]
+		if !ok {
+			t.Fatalf("symbol %q missing from profile", sym)
+		}
+		outUnit := pprofscale.SelectOutputUnit(d.SampleUnit, d.Total, d.Flat, d.Cum)
+		got := pprofscale.ScaledLabel(flat, d.SampleUnit, outUnit)
+		if got != label {
+			t.Fatalf("%s flat display=%q want %q (raw=%d outUnit=%q)", sym, got, label, flat, outUnit)
+		}
+	}
+
+	top := topSymbols(d, 5)
+	if len(top) == 0 {
+		t.Fatal("expected top symbols")
+	}
+	if top[0].Symbol != "crypto/internal/fips140/sha256.blockSHANI" || top[0].FlatDisplay != "0.19s" {
+		t.Fatalf("rank 1=%+v", top[0])
+	}
+	display, sec, outUnit := profileTotalDisplay(d)
+	if display != "3.15s" || sec != 3.15 || outUnit != "s" {
+		t.Fatalf("total display=%q seconds=%v outUnit=%q want 3.15s/s", display, sec, outUnit)
+	}
+}

--- a/internal/datamap/display_test.go
+++ b/internal/datamap/display_test.go
@@ -23,8 +23,8 @@ func cpuFixturePath(t *testing.T) string {
 	return ""
 }
 
-// Top rows must match go tool pprof -top display strings (same Scale/ScaledLabel as pprof).
-func TestTopSymbolDisplay_matchesPprofTop(t *testing.T) {
+// Display helpers must match go tool pprof -top for profile totals (used on profiles section).
+func TestPprofDisplay_matchesPprofTop(t *testing.T) {
 	t.Parallel()
 	path := cpuFixturePath(t)
 	d, err := parser.DefaultPipeline().RunFromPath(path)
@@ -51,13 +51,6 @@ func TestTopSymbolDisplay_matchesPprofTop(t *testing.T) {
 		}
 	}
 
-	top := topSymbols(d, 5)
-	if len(top) == 0 {
-		t.Fatal("expected top symbols")
-	}
-	if top[0].Symbol != "crypto/internal/fips140/sha256.blockSHANI" || top[0].FlatDisplay != "0.19s" {
-		t.Fatalf("rank 1=%+v", top[0])
-	}
 	display, sec, outUnit := profileTotalDisplay(d)
 	if display != "3.15s" || sec != 3.15 || outUnit != "s" {
 		t.Fatalf("total display=%q seconds=%v outUnit=%q want 3.15s/s", display, sec, outUnit)

--- a/internal/datamap/display_test.go
+++ b/internal/datamap/display_test.go
@@ -37,7 +37,7 @@ func TestPprofDisplay_matchesPprofTop(t *testing.T) {
 
 	want := map[string]string{
 		"crypto/internal/fips140/sha256.blockSHANI": "0.19s",
-		"runtime.memmove":                           "0.16s",
+		"runtime.memmove": "0.16s",
 	}
 	for sym, label := range want {
 		flat, ok := d.Flat[sym]

--- a/internal/datamap/types.go
+++ b/internal/datamap/types.go
@@ -15,22 +15,22 @@ const (
 
 // BenchmarkMap is the root document written to data_mapping/<Benchmark>/map.json.
 type BenchmarkMap struct {
-	SchemaVersion   int                           `json:"schema_version"`
-	Tag             string                        `json:"tag"`
-	Benchmark       string                        `json:"benchmark"`
-	Package         string                        `json:"package,omitempty"`
+	SchemaVersion      int                           `json:"schema_version"`
+	Tag                string                        `json:"tag"`
+	Benchmark          string                        `json:"benchmark"`
+	Package            string                        `json:"package,omitempty"`
 	RecommendedFlow    []string                      `json:"recommended_flow"`
 	ReadingGuide       map[string]string             `json:"reading_guide"`
 	ProfileCostColumns map[string]string             `json:"profile_cost_columns"`
 	ProfileCostTriage  string                        `json:"profile_cost_triage"`
 	Measurements       *MeasurementsSection          `json:"measurements,omitempty"`
-	Profiles        map[string]ProfileRef         `json:"profiles"`
-	Hotspots        map[string]HotspotSection     `json:"hotspots"`
-	CallTrees       map[string]CallTreeSection    `json:"call_trees"`
-	SourceLines     map[string]SourceLinesSection `json:"source_lines"`
-	CallGraphs      map[string]CallGraphRef       `json:"call_graphs,omitempty"`
-	Provenance      Provenance                    `json:"provenance"`
-	Status          Status                        `json:"status"`
+	Profiles           map[string]ProfileRef         `json:"profiles"`
+	Hotspots           map[string]HotspotSection     `json:"hotspots"`
+	CallTrees          map[string]CallTreeSection    `json:"call_trees"`
+	SourceLines        map[string]SourceLinesSection `json:"source_lines"`
+	CallGraphs         map[string]CallGraphRef       `json:"call_graphs,omitempty"`
+	Provenance         Provenance                    `json:"provenance"`
+	Status             Status                        `json:"status"`
 }
 
 // MeasurementsSection points at go test bench output.
@@ -53,14 +53,14 @@ type MeasurementSummary struct {
 
 // ProfileRef describes a raw pprof binary.
 type ProfileRef struct {
-	Path          string  `json:"path"`
-	Purpose       string  `json:"purpose"`
-	Description   string  `json:"description"`
-	TotalSamples  int64   `json:"total_samples,omitempty"`
-	SampleUnit    string  `json:"sample_unit,omitempty"`
-	OutputUnit    string  `json:"output_unit,omitempty"`
-	TotalDisplay  string  `json:"total_display,omitempty"`
-	TotalSeconds  float64 `json:"total_seconds,omitempty"`
+	Path         string  `json:"path"`
+	Purpose      string  `json:"purpose"`
+	Description  string  `json:"description"`
+	TotalSamples int64   `json:"total_samples,omitempty"`
+	SampleUnit   string  `json:"sample_unit,omitempty"`
+	OutputUnit   string  `json:"output_unit,omitempty"`
+	TotalDisplay string  `json:"total_display,omitempty"`
+	TotalSeconds float64 `json:"total_seconds,omitempty"`
 }
 
 // HotspotSection describes a pprof -top text artifact.

--- a/internal/datamap/types.go
+++ b/internal/datamap/types.go
@@ -51,10 +51,14 @@ type MeasurementSummary struct {
 
 // ProfileRef describes a raw pprof binary.
 type ProfileRef struct {
-	Path         string `json:"path"`
-	Purpose      string `json:"purpose"`
-	Description  string `json:"description"`
-	TotalSamples int64  `json:"total_samples,omitempty"`
+	Path          string  `json:"path"`
+	Purpose       string  `json:"purpose"`
+	Description   string  `json:"description"`
+	TotalSamples  int64   `json:"total_samples,omitempty"`
+	SampleUnit    string  `json:"sample_unit,omitempty"`
+	OutputUnit    string  `json:"output_unit,omitempty"`
+	TotalDisplay  string  `json:"total_display,omitempty"`
+	TotalSeconds  float64 `json:"total_seconds,omitempty"`
 }
 
 // HotspotSection describes a pprof -top text artifact.
@@ -63,17 +67,23 @@ type HotspotSection struct {
 	Purpose     string      `json:"purpose"`
 	Description string      `json:"description"`
 	Producer    string      `json:"producer"`
+	SampleUnit  string      `json:"sample_unit,omitempty"`
+	OutputUnit  string      `json:"output_unit,omitempty"`
 	TopSymbols  []TopSymbol `json:"top_symbols,omitempty"`
 }
 
 // TopSymbol is one ranked row from hotspot data.
 type TopSymbol struct {
-	Rank    int     `json:"rank"`
-	Symbol  string  `json:"symbol"`
-	Flat    int64   `json:"flat"`
-	Cum     int64   `json:"cum"`
-	FlatPct float64 `json:"flat_pct"`
-	CumPct  float64 `json:"cum_pct"`
+	Rank        int     `json:"rank"`
+	Symbol      string  `json:"symbol"`
+	Flat        int64   `json:"flat"`
+	Cum         int64   `json:"cum"`
+	FlatDisplay string  `json:"flat_display,omitempty"`
+	CumDisplay  string  `json:"cum_display,omitempty"`
+	FlatSeconds float64 `json:"flat_seconds,omitempty"`
+	CumSeconds  float64 `json:"cum_seconds,omitempty"`
+	FlatPct     float64 `json:"flat_pct"`
+	CumPct      float64 `json:"cum_pct"`
 }
 
 // CallTreeSection describes a pprof -tree text artifact.
@@ -97,13 +107,17 @@ type SourceLinesSection struct {
 
 // FunctionRef is one source_lines extract.
 type FunctionRef struct {
-	Path       string  `json:"path"`
-	FullSymbol string  `json:"full_symbol"`
-	Flat       int64   `json:"flat,omitempty"`
-	Cum        int64   `json:"cum,omitempty"`
-	FlatPct    float64 `json:"flat_pct,omitempty"`
-	CumPct     float64 `json:"cum_pct,omitempty"`
-	Status     string  `json:"status"`
+	Path        string  `json:"path"`
+	FullSymbol  string  `json:"full_symbol"`
+	Flat        int64   `json:"flat,omitempty"`
+	Cum         int64   `json:"cum,omitempty"`
+	FlatDisplay string  `json:"flat_display,omitempty"`
+	CumDisplay  string  `json:"cum_display,omitempty"`
+	FlatSeconds float64 `json:"flat_seconds,omitempty"`
+	CumSeconds  float64 `json:"cum_seconds,omitempty"`
+	FlatPct     float64 `json:"flat_pct,omitempty"`
+	CumPct      float64 `json:"cum_pct,omitempty"`
+	Status      string  `json:"status"`
 }
 
 // CallGraphRef describes an optional PNG call graph.

--- a/internal/datamap/types.go
+++ b/internal/datamap/types.go
@@ -19,9 +19,11 @@ type BenchmarkMap struct {
 	Tag             string                        `json:"tag"`
 	Benchmark       string                        `json:"benchmark"`
 	Package         string                        `json:"package,omitempty"`
-	RecommendedFlow []string                      `json:"recommended_flow"`
-	ReadingGuide    map[string]string             `json:"reading_guide"`
-	Measurements    *MeasurementsSection          `json:"measurements,omitempty"`
+	RecommendedFlow    []string                      `json:"recommended_flow"`
+	ReadingGuide       map[string]string             `json:"reading_guide"`
+	ProfileCostColumns map[string]string             `json:"profile_cost_columns"`
+	ProfileCostTriage  string                        `json:"profile_cost_triage"`
+	Measurements       *MeasurementsSection          `json:"measurements,omitempty"`
 	Profiles        map[string]ProfileRef         `json:"profiles"`
 	Hotspots        map[string]HotspotSection     `json:"hotspots"`
 	CallTrees       map[string]CallTreeSection    `json:"call_trees"`

--- a/internal/datamap/types.go
+++ b/internal/datamap/types.go
@@ -65,36 +65,19 @@ type ProfileRef struct {
 
 // HotspotSection describes a pprof -top text artifact.
 type HotspotSection struct {
-	Path        string      `json:"path"`
-	Purpose     string      `json:"purpose"`
-	Description string      `json:"description"`
-	Producer    string      `json:"producer"`
-	SampleUnit  string      `json:"sample_unit,omitempty"`
-	OutputUnit  string      `json:"output_unit,omitempty"`
-	TopSymbols  []TopSymbol `json:"top_symbols,omitempty"`
-}
-
-// TopSymbol is one ranked row from hotspot data.
-type TopSymbol struct {
-	Rank        int     `json:"rank"`
-	Symbol      string  `json:"symbol"`
-	Flat        int64   `json:"flat"`
-	Cum         int64   `json:"cum"`
-	FlatDisplay string  `json:"flat_display,omitempty"`
-	CumDisplay  string  `json:"cum_display,omitempty"`
-	FlatSeconds float64 `json:"flat_seconds,omitempty"`
-	CumSeconds  float64 `json:"cum_seconds,omitempty"`
-	FlatPct     float64 `json:"flat_pct"`
-	CumPct      float64 `json:"cum_pct"`
+	Path                string `json:"path"`
+	Purpose             string `json:"purpose"`
+	Description         string `json:"description"`
+	Producer            string `json:"producer"`
+	HotspotsMetricsNote string `json:"hotspots_metrics_note,omitempty"`
 }
 
 // CallTreeSection describes a pprof -tree text artifact.
 type CallTreeSection struct {
-	Path        string   `json:"path"`
-	Purpose     string   `json:"purpose"`
-	Description string   `json:"description"`
-	Producer    string   `json:"producer"`
-	HotPath     []string `json:"hot_path_summary,omitempty"`
+	Path        string `json:"path"`
+	Purpose     string `json:"purpose"`
+	Description string `json:"description"`
+	Producer    string `json:"producer"`
 }
 
 // SourceLinesSection indexes per-function -list extracts for one profile kind.
@@ -107,19 +90,11 @@ type SourceLinesSection struct {
 	Functions   map[string]FunctionRef `json:"functions"`
 }
 
-// FunctionRef is one source_lines extract.
+// FunctionRef is one source_lines extract (path mapping only; metrics are in hotspots text).
 type FunctionRef struct {
-	Path        string  `json:"path"`
-	FullSymbol  string  `json:"full_symbol"`
-	Flat        int64   `json:"flat,omitempty"`
-	Cum         int64   `json:"cum,omitempty"`
-	FlatDisplay string  `json:"flat_display,omitempty"`
-	CumDisplay  string  `json:"cum_display,omitempty"`
-	FlatSeconds float64 `json:"flat_seconds,omitempty"`
-	CumSeconds  float64 `json:"cum_seconds,omitempty"`
-	FlatPct     float64 `json:"flat_pct,omitempty"`
-	CumPct      float64 `json:"cum_pct,omitempty"`
-	Status      string  `json:"status"`
+	Path       string `json:"path"`
+	FullSymbol string `json:"full_symbol"`
+	Status     string `json:"status"`
 }
 
 // CallGraphRef describes an optional PNG call graph.

--- a/internal/pprofscale/scale.go
+++ b/internal/pprofscale/scale.go
@@ -11,6 +11,12 @@ import (
 	"time"
 )
 
+const (
+	unitAuto    = "auto"
+	unitMinimum = "minimum"
+	unitSeconds = "s"
+)
+
 // Scale converts value from fromUnit to toUnit. Returns scaled value and target unit
 // (empty when uninteresting). Matches pprof measurement.Scale.
 func Scale(value int64, fromUnit, toUnit string) (float64, string) {
@@ -24,7 +30,7 @@ func Scale(value int64, fromUnit, toUnit string) (float64, string) {
 		}
 	}
 	switch toUnit {
-	case "count", "sample", "unit", "minimum", "auto":
+	case "count", "sample", "unit", unitMinimum, unitAuto:
 		return float64(value), ""
 	default:
 		return float64(value), toUnit
@@ -43,8 +49,8 @@ func ScaledLabel(value int64, fromUnit, toUnit string) string {
 
 // Seconds converts a sample value to seconds when fromUnit is a time unit; ok is false otherwise.
 func Seconds(value int64, fromUnit string) (sec float64, ok bool) {
-	v, u := Scale(value, fromUnit, "s")
-	if u != "s" {
+	v, u := Scale(value, fromUnit, unitSeconds)
+	if u != unitSeconds {
 		return 0, false
 	}
 	return v, true
@@ -101,9 +107,9 @@ func (ut UnitType) convertUnit(value int64, fromUnitStr, toUnitStr string) (floa
 		return 0, "", false
 	}
 	v := float64(value) * fromUnit.Factor
-	if toUnitStr == "minimum" || toUnitStr == "auto" {
-		if v, u, ok := ut.autoScale(v); ok {
-			return v, u, true
+	if toUnitStr == unitMinimum || toUnitStr == unitAuto {
+		if scaled, u, ok := ut.autoScale(v); ok {
+			return scaled, u, true
 		}
 		return v / ut.DefaultUnit.Factor, ut.DefaultUnit.CanonicalName, true
 	}
@@ -152,7 +158,7 @@ func abs64(v int64) int64 {
 // Mirrors github.com/google/pprof/internal/report.Report.selectOutputUnit.
 func SelectOutputUnit(sampleUnit string, total int64, flat, cum map[string]int64) string {
 	if sampleUnit == "" {
-		return "auto"
+		return unitAuto
 	}
 	var minValue int64
 	seen := make(map[string]struct{}, len(flat))
@@ -179,11 +185,11 @@ func SelectOutputUnit(sampleUnit string, total int64, flat, cum map[string]int64
 	if minValue == 0 {
 		minValue = maxValue
 	}
-	_, minUnit := Scale(minValue, sampleUnit, "minimum")
-	_, maxUnit := Scale(maxValue, sampleUnit, "minimum")
+	_, minUnit := Scale(minValue, sampleUnit, unitMinimum)
+	_, maxUnit := Scale(maxValue, sampleUnit, unitMinimum)
 	unit := minUnit
 	if minUnit != maxUnit && minValue*100 < maxValue {
-		_, unit = Scale(100*minValue, sampleUnit, "minimum")
+		_, unit = Scale(100*minValue, sampleUnit, unitMinimum)
 	}
 	if unit != "" {
 		return unit

--- a/internal/pprofscale/scale.go
+++ b/internal/pprofscale/scale.go
@@ -1,0 +1,192 @@
+// Package pprofscale formats profile sample values using the same unit rules as
+// go tool pprof (github.com/google/pprof/internal/measurement). Logic is copied
+// so prof can match pprof -top output without importing pprof internal packages.
+package pprofscale
+
+import (
+	"fmt"
+	"math"
+	"slices"
+	"strings"
+	"time"
+)
+
+// Scale converts value from fromUnit to toUnit. Returns scaled value and target unit
+// (empty when uninteresting). Matches pprof measurement.Scale.
+func Scale(value int64, fromUnit, toUnit string) (float64, string) {
+	if value < 0 && -value > 0 {
+		v, u := Scale(-value, fromUnit, toUnit)
+		return -v, u
+	}
+	for _, ut := range unitTypes {
+		if v, u, ok := ut.convertUnit(value, fromUnit, toUnit); ok {
+			return v, u
+		}
+	}
+	switch toUnit {
+	case "count", "sample", "unit", "minimum", "auto":
+		return float64(value), ""
+	default:
+		return float64(value), toUnit
+	}
+}
+
+// ScaledLabel formats value like pprof -top (two decimal places in outputUnit).
+func ScaledLabel(value int64, fromUnit, toUnit string) string {
+	v, u := Scale(value, fromUnit, toUnit)
+	sv := strings.TrimSuffix(fmt.Sprintf("%.2f", v), ".00")
+	if sv == "0" || sv == "-0" {
+		return "0"
+	}
+	return sv + u
+}
+
+// Seconds converts a sample value to seconds when fromUnit is a time unit; ok is false otherwise.
+func Seconds(value int64, fromUnit string) (sec float64, ok bool) {
+	v, u := Scale(value, fromUnit, "s")
+	if u != "s" {
+		return 0, false
+	}
+	return v, true
+}
+
+// Unit includes aliases for a specific unit and factor to the base unit in its category.
+type Unit struct {
+	CanonicalName string
+	aliases       []string
+	Factor        float64
+}
+
+// UnitType groups units in one category (memory, time, …) with a default unit.
+type UnitType struct {
+	DefaultUnit Unit
+	Units       []Unit
+}
+
+func (ut UnitType) findByAlias(alias string) *Unit {
+	for _, u := range ut.Units {
+		if slices.Contains(u.aliases, alias) {
+			return &u
+		}
+	}
+	return nil
+}
+
+func (ut UnitType) sniffUnit(unit string) *Unit {
+	unit = strings.ToLower(unit)
+	if len(unit) > 2 {
+		unit = strings.TrimSuffix(unit, "s")
+	}
+	return ut.findByAlias(unit)
+}
+
+func (ut UnitType) autoScale(value float64) (float64, string, bool) {
+	var f float64
+	var unit string
+	for _, u := range ut.Units {
+		if u.Factor >= f && (value/u.Factor) >= 1.0 {
+			f = u.Factor
+			unit = u.CanonicalName
+		}
+	}
+	if f == 0 {
+		return 0, "", false
+	}
+	return value / f, unit, true
+}
+
+func (ut UnitType) convertUnit(value int64, fromUnitStr, toUnitStr string) (float64, string, bool) {
+	fromUnit := ut.sniffUnit(fromUnitStr)
+	if fromUnit == nil {
+		return 0, "", false
+	}
+	v := float64(value) * fromUnit.Factor
+	if toUnitStr == "minimum" || toUnitStr == "auto" {
+		if v, u, ok := ut.autoScale(v); ok {
+			return v, u, true
+		}
+		return v / ut.DefaultUnit.Factor, ut.DefaultUnit.CanonicalName, true
+	}
+	toUnit := ut.sniffUnit(toUnitStr)
+	if toUnit == nil {
+		return v / ut.DefaultUnit.Factor, ut.DefaultUnit.CanonicalName, true
+	}
+	return v / toUnit.Factor, toUnit.CanonicalName, true
+}
+
+// unitTypes matches github.com/google/pprof/internal/measurement.UnitTypes.
+var unitTypes = []UnitType{{
+	Units: []Unit{
+		{"B", []string{"b", "byte"}, 1},
+		{"kB", []string{"kb", "kbyte", "kilobyte"}, float64(1 << 10)},
+		{"MB", []string{"mb", "mbyte", "megabyte"}, float64(1 << 20)},
+		{"GB", []string{"gb", "gbyte", "gigabyte"}, float64(1 << 30)},
+		{"TB", []string{"tb", "tbyte", "terabyte"}, float64(1 << 40)},
+		{"PB", []string{"pb", "pbyte", "petabyte"}, float64(1 << 50)},
+	},
+	DefaultUnit: Unit{"B", []string{"b", "byte"}, 1},
+}, {
+	Units: []Unit{
+		{"ns", []string{"ns", "nanosecond"}, float64(time.Nanosecond)},
+		{"us", []string{"μs", "us", "microsecond"}, float64(time.Microsecond)},
+		{"ms", []string{"ms", "millisecond"}, float64(time.Millisecond)},
+		{"s", []string{"s", "sec", "second"}, float64(time.Second)},
+		{"hrs", []string{"hour", "hr"}, float64(time.Hour)},
+	},
+	DefaultUnit: Unit{"s", []string{}, float64(time.Second)},
+}}
+
+// RoundSeconds rounds to two decimal places like pprof ScaledLabel before stripping .00.
+func RoundSeconds(sec float64) float64 {
+	return math.Round(sec*100) / 100
+}
+
+func abs64(v int64) int64 {
+	if v < 0 {
+		return -v
+	}
+	return v
+}
+
+// SelectOutputUnit picks the display unit go tool pprof -top uses for an entire report.
+// Mirrors github.com/google/pprof/internal/report.Report.selectOutputUnit.
+func SelectOutputUnit(sampleUnit string, total int64, flat, cum map[string]int64) string {
+	if sampleUnit == "" {
+		return "auto"
+	}
+	var minValue int64
+	seen := make(map[string]struct{}, len(flat))
+	for sym, f := range flat {
+		seen[sym] = struct{}{}
+		nodeMin := abs64(f)
+		if nodeMin == 0 {
+			nodeMin = abs64(cum[sym])
+		}
+		if nodeMin > 0 && (minValue == 0 || nodeMin < minValue) {
+			minValue = nodeMin
+		}
+	}
+	for sym, c := range cum {
+		if _, ok := seen[sym]; ok {
+			continue
+		}
+		nodeMin := abs64(c)
+		if nodeMin > 0 && (minValue == 0 || nodeMin < minValue) {
+			minValue = nodeMin
+		}
+	}
+	maxValue := total
+	if minValue == 0 {
+		minValue = maxValue
+	}
+	_, minUnit := Scale(minValue, sampleUnit, "minimum")
+	_, maxUnit := Scale(maxValue, sampleUnit, "minimum")
+	unit := minUnit
+	if minUnit != maxUnit && minValue*100 < maxValue {
+		_, unit = Scale(100*minValue, sampleUnit, "minimum")
+	}
+	if unit != "" {
+		return unit
+	}
+	return sampleUnit
+}

--- a/internal/pprofscale/scale_test.go
+++ b/internal/pprofscale/scale_test.go
@@ -1,0 +1,56 @@
+package pprofscale
+
+import "testing"
+
+func TestScaledLabel_cpuNanoseconds(t *testing.T) {
+	t.Parallel()
+	got := ScaledLabel(1_470_000_000, "nanoseconds", "auto")
+	if got != "1.47s" {
+		t.Fatalf("got %q want 1.47s", got)
+	}
+}
+
+func TestSeconds_cpuNanoseconds(t *testing.T) {
+	t.Parallel()
+	sec, ok := Seconds(1_470_000_000, "nanoseconds")
+	if !ok {
+		t.Fatal("expected ok")
+	}
+	if sec != 1.47 {
+		t.Fatalf("got %v want 1.47", sec)
+	}
+}
+
+func TestScaledLabel_memoryBytes(t *testing.T) {
+	t.Parallel()
+	const bytes = int64(891_425_914) // 850.13 * 2^20
+	got := ScaledLabel(bytes, "bytes", "auto")
+	if got != "850.13MB" {
+		t.Fatalf("got %q want 850.13MB", got)
+	}
+}
+
+func TestSelectOutputUnit_cpuProfile(t *testing.T) {
+	t.Parallel()
+	flat := map[string]int64{"a": 10_000_000}
+	cum := map[string]int64{"a": 10_000_000}
+	const total = 3_150_000_000
+	got := SelectOutputUnit("nanoseconds", total, flat, cum)
+	if got != "s" {
+		t.Fatalf("got %q want s", got)
+	}
+	if ScaledLabel(190_000_000, "nanoseconds", got) != "0.19s" {
+		t.Fatal("expected 0.19s with profile output unit")
+	}
+}
+
+func TestScale_totalCPUProfile(t *testing.T) {
+	t.Parallel()
+	if ScaledLabel(10_220_000_000, "nanoseconds", "auto") != "10.22s" {
+		t.Fatal("total label mismatch")
+	}
+	sec, ok := Seconds(10_220_000_000, "nanoseconds")
+	if !ok || sec != 10.22 {
+		t.Fatalf("seconds=%v ok=%v", sec, ok)
+	}
+}

--- a/parser/aggregate.go
+++ b/parser/aggregate.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"sort"
+	"strings"
 
 	pprofprofile "github.com/google/pprof/profile"
 )
@@ -11,6 +12,10 @@ func AggregateProfileData(p *pprofprofile.Profile, valueIndex int) *ProfileData 
 	flat, cum := flatAndCumulativeFromSamples(p, valueIndex)
 	total := totalSampleValue(p, valueIndex)
 	flatPct, cumPct, sumPct, sorted := percentagesAndSort(flat, cum, total)
+	sampleUnit := ""
+	if valueIndex >= 0 && valueIndex < len(p.SampleType) && p.SampleType[valueIndex] != nil {
+		sampleUnit = strings.ToLower(p.SampleType[valueIndex].Unit)
+	}
 	return &ProfileData{
 		Flat:            flat,
 		Cum:             cum,
@@ -19,6 +24,7 @@ func AggregateProfileData(p *pprofprofile.Profile, valueIndex int) *ProfileData 
 		CumPercentages:  cumPct,
 		SumPercentages:  sumPct,
 		SortedEntries:   sorted,
+		SampleUnit:      sampleUnit,
 	}
 }
 

--- a/parser/pipeline.go
+++ b/parser/pipeline.go
@@ -154,10 +154,10 @@ func (StandardProfileValidator) Validate(p *pprofprofile.Profile) error {
 	return ValidateProfile(p)
 }
 
-// FirstSampleIndexSelector uses sample value index 0.
+// FirstSampleIndexSelector uses the last sample value index (pprof -top default).
 type FirstSampleIndexSelector struct{}
 
-// PrimaryIndex returns the primary sample value index (0).
+// PrimaryIndex returns the primary sample value index (last sample type).
 func (FirstSampleIndexSelector) PrimaryIndex(p *pprofprofile.Profile) (int, error) {
 	return PrimarySampleValueIndex(p)
 }

--- a/parser/profile_io.go
+++ b/parser/profile_io.go
@@ -43,12 +43,12 @@ func ValidateProfile(p *pprofprofile.Profile) error {
 }
 
 // PrimarySampleValueIndex returns the index into Sample.Value used for flat/cum aggregation.
-// Currently always 0 (first sample type); extend here to pick wall vs alloc, etc.
+// Uses the last sample type, matching go tool pprof report.NewDefault (pprof -top).
 func PrimarySampleValueIndex(p *pprofprofile.Profile) (int, error) {
 	if len(p.SampleType) == 0 {
 		return 0, errors.New("profile has no sample types")
 	}
-	return 0, nil
+	return len(p.SampleType) - 1, nil
 }
 
 // ValidateSamplesHaveValueAt ensures every sample has a value at the given index.

--- a/parser/types.go
+++ b/parser/types.go
@@ -9,6 +9,8 @@ type ProfileData struct {
 	CumPercentages  map[string]float64
 	SumPercentages  map[string]float64
 	SortedEntries   []FuncEntry
+	// SampleUnit is the pprof unit for Flat/Cum/Total (e.g. nanoseconds, bytes).
+	SampleUnit string
 }
 
 // FuncEntry is one symbol row sorted by flat cost (descending).


### PR DESCRIPTION
## Summary

- Align profile parsing with go tool pprof -top by using the last SampleType index and adding internal/pprofscale for display formatting on profile totals.
- Add profile_cost_columns, profile_cost_triage, and hotspots_metrics_note so agents can interpret hotspots text without guessing column meanings.
- Refactor map.json into an artifact index: drop duplicated top_symbols, per-function flat/cum on source_lines, and hot_path_summary. Metrics stay in hotspots/*.txt; map links paths only.

## Test plan

- [x] go test ./internal/datamap/ ./internal/pprofscale/ ./parser/ ./engine/collect/
- [x] Re-collect baseline; map.json shrinks ~21k to ~8k tokens (tiktoken) while hotspots text still matches pprof output

Made with [Cursor](https://cursor.com)